### PR TITLE
Fix the API dependency so that it correctly imports the API Snapshot

### DIFF
--- a/shared_sdk/pom.xml
+++ b/shared_sdk/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>com.google.appengine</groupId>
-            <artifactId>appengine-api-1.0-sdk</artifactId>
+            <artifactId>appengine-apis</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.appengine</groupId>


### PR DESCRIPTION
I wasn't able to cleanly import the project into intellij since the dependency from the shared_sdk was not for the API built in the project.
This change gives me a clean import and build.