### PR TITLE
fix deployment of extra assembly, there will be an extra assembly artifact called appengine-java-sdk-${version}-cloud-sdk-assembly.zip 

### DIFF
--- a/sdk_assembly/pom.xml
+++ b/sdk_assembly/pom.xml
@@ -293,12 +293,12 @@
                             <goal>single</goal>
                         </goals>
                         <configuration>
+                            <appendAssemblyId>true</appendAssemblyId>
                             <overrideUid>0</overrideUid>
                             <overrideGid>0</overrideGid>
                             <descriptors>
                                 <descriptor>src/main/assembly/cloud-sdk-assembly.xml</descriptor>
                             </descriptors>
-                              <finalName>google_appengine_java_delta_${project.version}</finalName>
                         </configuration>
                     </execution>
                     <!--execution>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
