### PR TITLE
Include JDK21 and above in the plugin configuration range.

### DIFF
--- a/appengine_testing_tests/pom.xml
+++ b/appengine_testing_tests/pom.xml
@@ -73,7 +73,7 @@
         <profile>
             <id>surefire-newerjava</id>
             <activation>
-                <jdk>[11,20)</jdk>
+                <jdk>[11,)</jdk>
             </activation>
             <build>
                 <plugins>
@@ -85,7 +85,10 @@
                                 -Duser.timezone=CST
                                 --add-opens java.base/java.lang=ALL-UNNAMED
                             </argLine>
-                        </configuration>
+                          <systemPropertyVariables>
+                            <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
+                        </systemPropertyVariables>
+                    </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/pom.xml
+++ b/pom.xml
@@ -235,8 +235,9 @@
                           <systemPropertyVariables>
                               <appengine.runtime.dir>../deployment/target/runtime-deployment-${project.version}</appengine.runtime.dir>
                               <com.google.apphosting.runtime.jetty94.LEGACY_MODE>true</com.google.apphosting.runtime.jetty94.LEGACY_MODE>
+                              <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
                           </systemPropertyVariables>
-                          <argLine>
+                        <argLine>
                               --add-opens java.base/java.lang=ALL-UNNAMED
                               --add-opens java.base/java.nio.charset=ALL-UNNAMED
                               --add-opens java.base/java.util.concurrent=ALL-UNNAMED


### PR DESCRIPTION
trying to address https://github.com/raphw/byte-buddy/issues/1396 as well.

PiperOrigin-RevId: 572035592
Change-Id: I9f6fe1ad19c78384ac5be7a4a147420aaf7363a5