### PR TITLE
Upgrade to jetty-9.4.53.v20231009

### DIFF
--- a/kokoro/gcp_ubuntu/build.sh
+++ b/kokoro/gcp_ubuntu/build.sh
@@ -30,7 +30,7 @@ export JAVA_HOME="$(update-java-alternatives -l | grep "1.17" | head -n 1 | tr -
 echo "JAVA_HOME = $JAVA_HOME"
 ./mvnw -v
 
-./mvnw -e clean install cyclonedx:makeAggregateBom
+./mvnw -e clean install  spdx:createSPDX
 
 # The artifacts under `${KOKORO_ARTIFACTS_DIR}/maven-artifacts` will be uploaded as a zip file named maven_jars.binary
 TMP_STAGING_LOCATION=${KOKORO_ARTIFACTS_DIR}/tmp
@@ -70,8 +70,7 @@ chmod a+x ${TMP_STAGING_LOCATION}/appengine-java-sdk/bin/*
 cp sdk_assembly/target/google_appengine_java_delta*.zip ${TMP_STAGING_LOCATION}/google_appengine_java_delta_from_maven.zip
 
 # Add SBOM files:
-cp target/bom.json ${TMP_STAGING_LOCATION}/
-cp target/bom.xml ${TMP_STAGING_LOCATION}/
+cp target/site/com.google.appengine_parent-*.json ${TMP_STAGING_LOCATION}/com.google.appengine_parent.spdx.json
 
 cd ${TMP_STAGING_LOCATION}
 zip -r ${PUBLISHED_LOCATION}/maven_jars.binary .

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.52.v20230823</jetty.version>
+    <jetty.version>9.4.53.v20231009</jetty.version>
     <jetty12.version>12.0.1</jetty12.version>
     <distributionManagement.snapshot.url>https://oss.sonatype.org/content/repositories/google-snapshots/</distributionManagement.snapshot.url>
     <distributionManagement.snapshot.id>sonatype-nexus-snapshots</distributionManagement.snapshot.id>


### PR DESCRIPTION
#10679 - backport HTTP/2 rate control from Jetty 10.0.x #10573 - backport hpack improvements from Jetty 10.0.x #10546 - backport jetty-http Huffman encoders/decoders from Jetty 10.0.x

Addresses CVE-2023-44487 and CVE-2023-36478 which have to do with HTTP/2.

see https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.53.v20231009

PiperOrigin-RevId: 572300688
Change-Id: Ic60a19d425798ccbe171a57191895dd803672541