### PR TITLE
fix logging for Jetty 12 EE8/EE10

### DIFF
--- a/lib/tools_api/pom.xml
+++ b/lib/tools_api/pom.xml
@@ -39,7 +39,7 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <optional>true</optional>
-      <version>2.0.7</version>
+      <version>${slf4j.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.53.v20231009</jetty.version>
     <jetty12.version>12.0.2</jetty12.version>
+    <slf4j.version>2.0.9</slf4j.version>
     <distributionManagement.snapshot.url>https://oss.sonatype.org/content/repositories/google-snapshots/</distributionManagement.snapshot.url>
     <distributionManagement.snapshot.id>sonatype-nexus-snapshots</distributionManagement.snapshot.id>
     <distributionManagement.release.url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</distributionManagement.release.url>

--- a/runtime/local_jetty12/src/main/java/com/google/appengine/tools/development/jetty/JettyContainerService.java
+++ b/runtime/local_jetty12/src/main/java/com/google/appengine/tools/development/jetty/JettyContainerService.java
@@ -120,13 +120,6 @@ public class JettyContainerService extends AbstractContainerService implements C
   private static final String APPENGINE_WEB_XML_ATTR =
       "com.google.appengine.tools.development.appEngineWebXml";
 
-  static {
-    // Tell Jetty to use our custom logging class (that forwards to
-    // java.util.logging) instead of writing to System.err.
-    System.setProperty(
-        "org.eclipse.jetty.util.log.class", " com.google.appengine.development.jetty.JettyLogger");
-  }
-
   private static final int SCAN_INTERVAL_SECONDS = 5;
 
   /** Jetty webapp context. */

--- a/runtime/local_jetty12_ee10/src/main/java/com/google/appengine/tools/development/jetty/ee10/JettyContainerService.java
+++ b/runtime/local_jetty12_ee10/src/main/java/com/google/appengine/tools/development/jetty/ee10/JettyContainerService.java
@@ -124,13 +124,6 @@ public class JettyContainerService extends AbstractContainerService
   private static final String APPENGINE_WEB_XML_ATTR =
       "com.google.appengine.tools.development.appEngineWebXml";
 
-  static {
-    // Tell Jetty to use our custom logging class (that forwards to
-    // java.util.logging) instead of writing to System.err.
-    System.setProperty(
-        "org.eclipse.jetty.util.log.class", " com.google.appengine.development.jetty.JettyLogger");
-  }
-
   private static final int SCAN_INTERVAL_SECONDS = 5;
 
   /** Jetty webapp context. */

--- a/runtime/runtime_impl_jetty12/pom.xml
+++ b/runtime/runtime_impl_jetty12/pom.xml
@@ -571,7 +571,7 @@
                                     <include>org.eclipse.jetty:jetty-server</include>
                                     <include>org.eclipse.jetty:jetty-session</include>
                                     <include>org.eclipse.jetty:jetty-security</include>
-                                    <include>org.eclipse.jetty:jetty-slf4j-impl</include>
+                                    <include>org.slf4j:slf4j-jdk14</include>
                                     <include>org.slf4j:slf4j-api</include>
                                     <include>org.eclipse.jetty:jetty-util-ajax</include>
                                     <include>org.eclipse.jetty:jetty-util</include>

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
@@ -65,11 +65,6 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
   private AppVersionKey lastAppVersionKey;
 
   static {
-    // Tell Jetty to use our custom logging class (that forwards to
-    // java.util.logging) instead of writing to System.err
-    // Documentation: http://www.eclipse.org/jetty/documentation/current/configuring-logging.html
-    // TODO: re-enable logging.
-    // System.setProperty("org.eclipse.jetty.util.log.class", JettyLogger.class.getName());
     // Remove internal URLs.
     System.setProperty("java.vendor.url", "");
     System.setProperty("java.vendor.url.bug", "");

--- a/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyServletEngineAdapter.java
+++ b/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyServletEngineAdapter.java
@@ -25,7 +25,6 @@ import com.google.apphosting.base.protos.RuntimePb.UPResponse;
 import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.runtime.MutableUpResponse;
 import com.google.apphosting.runtime.ServletEngineAdapter;
-import com.google.apphosting.runtime.jetty9.JettyLogger;
 import com.google.apphosting.utils.config.AppEngineConfigException;
 import com.google.apphosting.utils.config.AppYaml;
 import com.google.common.flogger.GoogleLogger;

--- a/shared_sdk_jetty12/pom.xml
+++ b/shared_sdk_jetty12/pom.xml
@@ -58,9 +58,9 @@
             <version>${jetty12.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-slf4j-impl</artifactId>
-             <version>${jetty12.version}</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <version>${slf4j.version}</version>
          </dependency>
         <dependency>
             <groupId>org.eclipse.jetty.ee8</groupId>


### PR DESCRIPTION
use `org.slf4j:slf4j-jdk14` to bind SLF4J to `java.util.logging`

I have tested this and the logs no longer go to stderr but to `projects/jetty9-work/logs/%2Fvar%2Flog%2Fapp`