### PR TITLE
Use HttpStream.Wrapper for completion listener in JettyContainerService

### DIFF
--- a/api_dev/src/main/java/com/google/appengine/tools/development/ApiProxyLocalImpl.java
+++ b/api_dev/src/main/java/com/google/appengine/tools/development/ApiProxyLocalImpl.java
@@ -203,10 +203,12 @@ public class ApiProxyLocalImpl implements ApiProxyLocal, DevServices {
     Semaphore semaphore = (Semaphore) environment.getAttributes().get(
         LocalEnvironment.API_CALL_SEMAPHORE);
     if (semaphore != null) {
-     // TODO: investigate why the acquire() locks when Sessions are configured in appengine-web.xml
-     // Maybe the semaphore has been released just before the app engine session manager starts
-     // saving the data in datastore.
-      semaphore.tryAcquire();
+      try {
+        semaphore.acquire();
+      } catch (InterruptedException ex) {
+        // We never do this, so just propagate it as a RuntimeException for now.
+        throw new RuntimeException("Interrupted while waiting on semaphore:", ex);
+      }
     }
     AsyncApiCall asyncApiCall =
         new AsyncApiCall(environment, packageName, methodName, requestBytes, semaphore);

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.53.v20231009</jetty.version>
-    <jetty12.version>12.0.2</jetty12.version>
+    <jetty12.version>12.0.3</jetty12.version>
     <slf4j.version>2.0.9</slf4j.version>
     <distributionManagement.snapshot.url>https://oss.sonatype.org/content/repositories/google-snapshots/</distributionManagement.snapshot.url>
     <distributionManagement.snapshot.id>sonatype-nexus-snapshots</distributionManagement.snapshot.id>


### PR DESCRIPTION
Use a `HttpStream.Wrapper` for the completion listener in `JettyContainerService`.

We were previously using `Callback` for the `onCompletion` event in `JettyContainerService`, this tries to acquire all of the Semaphore permits to wait for all API calls to complete.

However the callback is invoked before the the `HttpStream`, and the `SessionManager` uses an `HttpStream.Wrapper` for its `doComplete` which was eventually calling the `DatastoreApiHelper` which was event doing an `ApiProxy` call.


This fixes the EE10 guestbook app.