### PR TITLE
changes to improve debugging for JavaRuntimeViaHttpBase

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/proxy/JettyHttpProxy.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/proxy/JettyHttpProxy.java
@@ -73,8 +73,6 @@ import org.eclipse.jetty.util.Callback;
  */
 public class JettyHttpProxy {
   private static final GoogleLogger logger = GoogleLogger.forEnclosingClass();
-  private static final String JETTY_LOG_CLASS = "org.eclipse.jetty.util.log.class";
-  private static final String JETTY_STDERRLOG = "org.eclipse.jetty.util.log.StdErrLog";
   private static final long MAX_REQUEST_SIZE = 32 * 1024 * 1024;
 
   /**
@@ -83,8 +81,6 @@ public class JettyHttpProxy {
    */
   public static void startServer(ServletEngineAdapter.Config runtimeOptions) {
     try {
-      System.setProperty(JETTY_LOG_CLASS, JETTY_STDERRLOG);
-
       ForwardingHandler handler = new ForwardingHandler(runtimeOptions, System.getenv());
       handler.init();
       Server server = newServer(runtimeOptions, handler);

--- a/runtime/test/pom.xml
+++ b/runtime/test/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
-    <debug.forked.process>false</debug.forked.process>
   </properties>
   <dependencies>
     <dependency>
@@ -125,7 +124,7 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <configuration>
             <systemPropertyVariables>
-              <debug.forked.process>${debug.forked.process}</debug.forked.process>
+              <appengine.debug.port>${appengine.debug.port}</appengine.debug.port>
             </systemPropertyVariables>
           </configuration>
         </plugin>

--- a/runtime/test/pom.xml
+++ b/runtime/test/pom.xml
@@ -30,6 +30,7 @@
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
+    <debug.forked.process>false</debug.forked.process>
   </properties>
   <dependencies>
     <dependency>
@@ -108,5 +109,27 @@
       <artifactId>appengine-utils</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>4.2.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <systemPropertyVariables>
+              <debug.forked.process>${debug.forked.process}</debug.forked.process>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 </project>

--- a/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/JavaRuntimeViaHttpBase.java
+++ b/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/JavaRuntimeViaHttpBase.java
@@ -247,8 +247,9 @@ public abstract class JavaRuntimeViaHttpBase {
 
       ImmutableList.Builder<String> builder = ImmutableList.<String>builder();
           builder.add(JAVA_HOME.value() + "/bin/java");
-          if (Boolean.getBoolean("debug.forked.process")) {
-            builder.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:8000");
+          Integer debugPort = Integer.getInteger("appengine.debug.port");
+          if (debugPort != null) {
+            builder.add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:" + debugPort);
           }
           builder.add(
                   "-Dcom.google.apphosting.runtime.jetty94.LEGACY_MODE=" + useJetty94LegacyMode(),

--- a/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/SpringBootTest.java
+++ b/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/SpringBootTest.java
@@ -62,7 +62,7 @@ public final class SpringBootTest extends JavaRuntimeViaHttpBase {
 
   private static List<String> readOutput(InputStream inputStream) throws IOException {
     try (BufferedReader output = new BufferedReader(new InputStreamReader(inputStream))) {
-      return output.lines().collect(Collectors.toList());
+      return output.lines().map(l -> l + "\n").collect(Collectors.toList());
     }
   }
 


### PR DESCRIPTION
- wait for port to be open after starting jetty in separate process instead of an arbitrary `Thread.sleep`.
- Use the `appengine.debug.port` system property to set the debug port for the new process.
- Some other minor cleanups.