### PR TITLE
Update Jetty 12 version to 12.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.53.v20231009</jetty.version>
-    <jetty12.version>12.0.3</jetty12.version>
+    <jetty12.version>12.0.4</jetty12.version>
     <slf4j.version>2.0.9</slf4j.version>
     <distributionManagement.snapshot.url>https://oss.sonatype.org/content/repositories/google-snapshots/</distributionManagement.snapshot.url>
     <distributionManagement.snapshot.id>sonatype-nexus-snapshots</distributionManagement.snapshot.id>


### PR DESCRIPTION
This includes a fix for the CombinedResource issue that was encountered when using quickstart with GAE on the springboot example webapp.