### PR TITLE
Fix typo in "appengine.use.EE8"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Source code for all public APIs for com.google.appengine.api.* packages.
 
       <!-- Add optionally:
       <system-properties>
-        <property name="appegine.use.EE8" value="true"/>
+        <property name="appengine.use.EE8" value="true"/>
     </system-properties>
     If you want to keep javax.servlet APIs and not jarkata.servlet by default
     -->


### PR DESCRIPTION
Took me a while to figure out why it didn't work after copy/pasting the line from the docs.