### PR TITLE
Issue #85 - fixes for CoreSizeLimitHandler

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/CoreSizeLimitHandler.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/CoreSizeLimitHandler.java
@@ -16,20 +16,19 @@
 
 package com.google.apphosting.runtime.jetty;
 
-import java.nio.ByteBuffer;
 import org.eclipse.jetty.http.BadMessageException;
 import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.HttpStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
+
+import java.nio.ByteBuffer;
 
 /**
  * A handler that can limit the size of message bodies in requests and responses.
@@ -72,79 +71,90 @@ public class CoreSizeLimitHandler extends Handler.Wrapper
       }
     }
 
-    HttpFields.Mutable.Wrapper httpFields = new HttpFields.Mutable.Wrapper(response.getHeaders())
+    SizeLimitRequestWrapper wrappedRequest = new SizeLimitRequestWrapper(request);
+    SizeLimitResponseWrapper wrappedResponse = new SizeLimitResponseWrapper(wrappedRequest, response);
+    return super.handle(wrappedRequest, wrappedResponse, callback);
+  }
+
+  private class SizeLimitRequestWrapper extends Request.Wrapper
+  {
+    private long _read = 0;
+
+    public SizeLimitRequestWrapper(Request wrapped)
     {
-      @Override
-      public HttpField onAddField(HttpField field)
-      {
-        if (field.getHeader().is(HttpHeader.CONTENT_LENGTH.asString()))
-        {
-          long contentLength = field.getLongValue();
-          if (_responseLimit >= 0 && contentLength > _responseLimit)
-            throw new HttpException.RuntimeException(HttpStatus.INTERNAL_SERVER_ERROR_500, "Response body is too large: " + contentLength + ">" + _responseLimit);
-        }
-        return super.onAddField(field);
-      }
-    };
+      super(wrapped);
+    }
 
-    response = new Response.Wrapper(request, response)
+    @Override
+    public Content.Chunk read()
     {
-      @Override
-      public HttpFields.Mutable getHeaders()
-      {
-        return httpFields;
-      }
-    };
-
-    request.addHttpStreamWrapper(httpStream -> new HttpStream.Wrapper(httpStream)
-    {
-      private long _read = 0;
-      private long _written = 0;
-
-      @Override
-      public Content.Chunk read()
-      {
-        Content.Chunk chunk = super.read();
-        if (chunk == null)
-          return null;
-        if (chunk.getFailure() != null)
-          return chunk;
-
-        // Check request content limit.
-        ByteBuffer content = chunk.getByteBuffer();
-        if (content != null && content.remaining() > 0)
-        {
-          _read += content.remaining();
-          if (_requestLimit >= 0 && _read > _requestLimit)
-          {
-            BadMessageException e = new BadMessageException(HttpStatus.PAYLOAD_TOO_LARGE_413, "Request body is too large: " + _read + ">" + _requestLimit);
-            request.fail(e);
-            return null;
-          }
-        }
-
+      Content.Chunk chunk = super.read();
+      if (chunk == null)
+        return null;
+      if (chunk.getFailure() != null)
         return chunk;
-      }
 
-      @Override
-      public void send(MetaData.Request request, MetaData.Response response, boolean last, ByteBuffer content, Callback callback)
+      // Check request content limit.
+      ByteBuffer content = chunk.getByteBuffer();
+      if (content != null && content.remaining() > 0)
       {
-        // Check response content limit.
-        if (content != null && content.remaining() > 0)
+        _read += content.remaining();
+        if (_requestLimit >= 0 && _read > _requestLimit)
         {
-          if (_responseLimit >= 0 && (_written + content.remaining())  > _responseLimit)
-          {
-            callback.failed(new HttpException.RuntimeException(HttpStatus.INTERNAL_SERVER_ERROR_500, "Response body is too large: " +
-                    _written + content.remaining() + ">" + _responseLimit));
-            return;
-          }
-          _written += content.remaining();
+          BadMessageException e = new BadMessageException(HttpStatus.PAYLOAD_TOO_LARGE_413, "Request body is too large: " + _read + ">" + _requestLimit);
+          getWrapped().fail(e);
+          return null;
         }
-
-        super.send(request, response, last, content, callback);
       }
-    });
 
-    return super.handle(request, response, callback);
+      return chunk;
+    }
+  }
+
+  private class SizeLimitResponseWrapper extends Response.Wrapper
+  {
+    private final HttpFields.Mutable _httpFields;
+    private long _written = 0;
+
+    public SizeLimitResponseWrapper(Request request, Response wrapped) {
+      super(request, wrapped);
+
+      _httpFields = new HttpFields.Mutable.Wrapper(wrapped.getHeaders())
+      {
+        @Override
+        public HttpField onAddField(HttpField field)
+        {
+          if (field.getHeader().is(HttpHeader.CONTENT_LENGTH.asString()))
+          {
+            long contentLength = field.getLongValue();
+            if (_responseLimit >= 0 && contentLength > _responseLimit)
+              throw new HttpException.RuntimeException(HttpStatus.INTERNAL_SERVER_ERROR_500, "Response body is too large: " + contentLength + ">" + _responseLimit);
+          }
+          return super.onAddField(field);
+        }
+      };
+    }
+
+    @Override
+    public HttpFields.Mutable getHeaders() {
+      return _httpFields;
+    }
+
+    @Override
+    public void write(boolean last, ByteBuffer content, Callback callback)
+    {
+      if (content != null && content.remaining() > 0)
+      {
+        if (_responseLimit >= 0 && (_written + content.remaining())  > _responseLimit)
+        {
+          callback.failed(new HttpException.RuntimeException(HttpStatus.INTERNAL_SERVER_ERROR_500, "Response body is too large: " +
+                  _written + content.remaining() + ">" + _responseLimit));
+          return;
+        }
+        _written += content.remaining();
+      }
+
+      super.write(last, content, callback);
+    }
   }
 }


### PR DESCRIPTION
## Issue #85

`CoreSizeLimitHandler` was not resetting its read/written counts for each request.

While testing this fix I also discovered that because it is using an `HttpStream.Wrapper` it is bypassing the `GzipHandler`, so I have changed this to also wrap the `Request` and `Response` instead of relying on wrapping the stream.

Note this `CoreSizeLimitHandler` is only used for Jetty 12 code, the Jetty 9 one does not have these issues.