### PR TITLE
set upResponse.setError with ERROR.OK_VALUE for successful requests

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/impl/DelegateRpcExchange.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/impl/DelegateRpcExchange.java
@@ -127,6 +127,7 @@ public class DelegateRpcExchange implements DelegateExchange {
   @Override
   public void succeeded() {
     _response.setHttpResponseResponse(ByteString.copyFrom(accumulator.takeByteBuffer()));
+    _response.setError(RuntimePb.UPResponse.ERROR.OK_VALUE);
     _completion.complete(null);
   }
 


### PR DESCRIPTION
When running tests I get the following exception:

```
[stderr] WARNING: Cannot build UPResponse
[stderr] com.google.protobuf.UninitializedMessageException: Message missing required fields: error
[stderr]        at com.google.protobuf.AbstractMessage$Builder.newUninitializedMessageException(AbstractMessage.java:470)
[stderr]        at com.google.apphosting.base.protos.RuntimePb$UPResponse$Builder.build(RuntimePb.java:11495)
[stderr]        at com.google.apphosting.runtime.MutableUpResponse.build(MutableUpResponse.java:60)
[stderr]        at com.google.apphosting.runtime.RequestRunner.run(RequestRunner.java:207)
[stderr]        at com.google.apphosting.runtime.ThreadGroupPool$PoolEntry.run(ThreadGroupPool.java:273)
[stderr]        at java.base/java.lang.Thread.run(Thread.java:1583)
```

to avoid this I have changed the `DelegateRpcExchange` to set `_response.setError(RuntimePb.UPResponse.ERROR.OK_VALUE)` when the callback is succeeded. Otherwise if the callback is failed, `_completion` will be failed and it will be caught in the `JettyServletEngineAdapter` which will do a `setError` on the `MutableUpResponse`.