### PR TITLE
set scheme to HTTPS if HttpPb.HttpRequest.getIsHttps() is true

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/api/DelegateExchange.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/api/DelegateExchange.java
@@ -38,6 +38,8 @@ public interface DelegateExchange extends Content.Source, Content.Sink, Callback
 
     InetSocketAddress getLocalAddr();
 
+    boolean isSecure();
+
     // Response Methods
 
     void setStatus(int status);

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/impl/DelegateRpcExchange.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/impl/DelegateRpcExchange.java
@@ -93,6 +93,11 @@ public class DelegateRpcExchange implements DelegateExchange {
   }
 
   @Override
+  public boolean isSecure() {
+    return _request.getIsHttps();
+  }
+
+  @Override
   public Content.Chunk read() {
     return _content.getAndUpdate(chunk -> (chunk instanceof ContentChunk) ? EOF : chunk);
   }

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/internal/DelegateConnection.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/internal/DelegateConnection.java
@@ -24,6 +24,7 @@ import java.util.EventListener;
 import java.util.concurrent.TimeoutException;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
@@ -116,13 +117,12 @@ public class DelegateConnection implements Connection {
       ConnectionMetaData connectionMetaData =
           new DelegateConnectionMetadata(_endpoint, this, _connector);
       HttpChannelState httpChannel = new HttpChannelState(connectionMetaData);
-
-      // TODO: This needs HttpChannel to implement demand().
       httpChannel.setHttpStream(new DelegateHttpStream(_endpoint, this, httpChannel));
 
       // Generate the Request MetaData.
       String method = delegateExchange.getMethod();
-      HttpURI httpURI = HttpURI.build(delegateExchange.getRequestURI());
+      HttpURI httpURI = HttpURI.build(delegateExchange.getRequestURI())
+              .scheme(delegateExchange.isSecure() ? HttpScheme.HTTPS : HttpScheme.HTTP);
       HttpVersion httpVersion = HttpVersion.fromString(delegateExchange.getProtocol());
       HttpFields httpFields = delegateExchange.getHeaders();
       long contentLength =


### PR DESCRIPTION
Set scheme to HTTPS if the `HttpPb.HttpRequest` returns true for `getIsHttps()`.

This will allow security constraints requiring confidential or integral to work without returning 403.