### PR TITLE
Update Jetty version to 9.4.54

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jetty.version>9.4.53.v20231009</jetty.version>
+    <jetty.version>9.4.54.v20240208</jetty.version>
     <jetty12.version>12.0.6</jetty12.version>
     <slf4j.version>2.0.9</slf4j.version>
     <distributionManagement.snapshot.url>https://oss.sonatype.org/content/repositories/google-snapshots/</distributionManagement.snapshot.url>


### PR DESCRIPTION
see https://github.com/jetty/jetty.project/releases/tag/jetty-9.4.54.v20240208


* #1256 DoSFilter leaks USER_AUTH entries
* #11259 HTTP/2 connection not closed after idle timeout when TCP congested
* #11389 Strip default ports on ws/wss scheme uris too