### PR TITLE
Add dummy value for Jetty 9 logging system property when using Jetty 12.

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
@@ -16,8 +16,6 @@
 
 package com.google.apphosting.runtime.jetty;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import com.google.apphosting.base.AppVersionKey;
 import com.google.apphosting.base.protos.AppinfoPb;
 import com.google.apphosting.base.protos.RuntimePb.UPRequest;
@@ -32,18 +30,21 @@ import com.google.apphosting.runtime.jetty.proxy.JettyHttpProxy;
 import com.google.apphosting.utils.config.AppEngineConfigException;
 import com.google.apphosting.utils.config.AppYaml;
 import com.google.common.flogger.GoogleLogger;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.InputStreamReader;
-import java.util.Objects;
-import java.util.concurrent.ExecutionException;
 import org.eclipse.jetty.http.CookieCompliance;
 import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.VirtualThreads;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStreamReader;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * This is an implementation of ServletEngineAdapter that uses the third-party Jetty servlet engine.
@@ -66,6 +67,10 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
   private AppVersionKey lastAppVersionKey;
 
   static {
+    // Set legacy system property to dummy value because external libraries (google-auth-library-java)
+    // test if this value is null to decide whether it is Java 7 runtime.
+    System.setProperty("org.eclipse.jetty.util.log.class", "DEPRECATED");
+
     // Remove internal URLs.
     System.setProperty("java.vendor.url", "");
     System.setProperty("java.vendor.url.bug", "");


### PR DESCRIPTION
see https://github.com/jetty/jetty.project/issues/11499


The code in https://github.com/googleapis/google-auth-library-java/blob/main/oauth2_http/java/com/google/auth/oauth2/DefaultCredentialsProvider.java#L321 is checking the `org.eclipse.jetty.util.log.class` system property to determine whether it is on GAE Standard 7. But this system property was not set for Jetty 12 because we use the SLF4J to JUL bridge.

If we set this property to a dummy value we can make Jetty 12 work better with `google-auth-library-java`.

I experienced this issue when trying to use `google-cloud-logging-logback` for google cloud logging with logback on the Java21 runtime. And got errors saying:
```
ERROR: onFailure exception: com.google.cloud.logging.LoggingException: 
io.grpc.StatusRuntimeException: PERMISSION_DENIED: Method doesn't allow 
unregistered callers (callers without established identity). Please use 
API Key or other form of API consumer identity to call this API.
```

I have tested the logging after this change and it works without any errors.