### PR TITLE
do not print stacktrace if logging file cannot be found

### DIFF
--- a/runtime/impl/src/main/java/com/google/apphosting/runtime/Logging.java
+++ b/runtime/impl/src/main/java/com/google/apphosting/runtime/Logging.java
@@ -16,8 +16,7 @@
 
 package com.google.apphosting.runtime;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
+import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
 import java.io.FileInputStream;
@@ -40,7 +39,8 @@ import java.util.logging.LogManager;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
-import javax.annotation.Nullable;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /** Configures logging for the GAE Java Runtime. */
 public final class Logging {
@@ -167,7 +167,12 @@ public final class Logging {
     try {
       printStream = new PrintStream(logPath.toFile());
     } catch (FileNotFoundException e) {
-      logger.log(Level.WARNING, "Unable to create log handler to " + logPath, e);
+      if (logger.isLoggable(Level.FINE)) {
+        logger.log(Level.WARNING, "Unable to create log handler to " + logPath, e);
+      }
+      else {
+        logger.log(Level.WARNING, "Unable to create log handler to " + logPath);
+      }
       return;
     }
 


### PR DESCRIPTION
This causes a warning stacktrace when used with local debugging and you don't have the /var/log/app file created with right permissions.

Normally when debugging locally you don't want this file anyway, because then it logs to the file and you can't see the output in the console.