### PR TITLE
Bug fix to allow applications to add Jetty servlets and filters.

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
@@ -35,6 +35,8 @@ import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.VirtualThreads;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
 
 import java.io.File;
@@ -104,11 +106,20 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
       threadPool.setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
       logger.atInfo().log("Configuring Appengine web server virtual threads.");
     }
+
+    // The server.getDefaultStyleSheet() returns is returning null because of some classloading issue,
+    // so we get the StyleSheet here to ensure it returns the correct value.
+    Resource styleSheet = ResourceFactory.root().newResource(getClass().getClassLoader().getResource("jetty-dir.css"));
     server =
         new Server(threadPool) {
           @Override
           public InvocationType getInvocationType() {
             return InvocationType.BLOCKING;
+          }
+
+          @Override
+          public Resource getDefaultStyleSheet() {
+            return styleSheet;
           }
         };
 


### PR DESCRIPTION
Jetty Servlets like the `DefaultServlet` require classes contained in `runtime-impl-jetty12.jar` to run so it can't be done by the application classloader.

The logic inside `AppEngineWebAppContext.startContext` is being run before the processing of `web.xml` and so the Jetty servlets were not being instantiated. I used a hack with a `ListenerHolder.doStart` to get around this but maybe there is some better interception point for this.

Also `server.getDefaultStyleSheet()` was returning null due to some classloader behaviour causing the default servlet not to start. So I also have a workaround for this.