### PR TITLE
update Jetty version to 12.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.54.v20240208</jetty.version>
-    <jetty12.version>12.0.8</jetty12.version>
+    <jetty12.version>12.0.9</jetty12.version>
     <slf4j.version>2.0.13</slf4j.version>
     <distributionManagement.snapshot.url>https://oss.sonatype.org/content/repositories/google-snapshots/</distributionManagement.snapshot.url>
     <distributionManagement.snapshot.id>sonatype-nexus-snapshots</distributionManagement.snapshot.id>

--- a/runtime/runtime_impl_jetty12/pom.xml
+++ b/runtime/runtime_impl_jetty12/pom.xml
@@ -563,6 +563,7 @@
                                     <include>org.eclipse.jetty.ee10:jetty-ee10-servlet</include>
                                     <include>org.eclipse.jetty.ee10:jetty-ee10-servlets</include>
                                     <include>org.eclipse.jetty.ee10:jetty-ee10-webapp</include>
+                                    <include>org.eclipse.jetty:jetty-ee</include>
                                     <include>org.eclipse.jetty:jetty-client</include>
                                     <include>org.eclipse.jetty:jetty-continuation</include>
                                     <include>org.eclipse.jetty:jetty-http</include>

--- a/shared_sdk_jetty12/pom.xml
+++ b/shared_sdk_jetty12/pom.xml
@@ -74,6 +74,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-ee</artifactId>
+            <version>${jetty12.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-security</artifactId>
             <version>${jetty12.version}</version>
         </dependency>


### PR DESCRIPTION
Upgrade Jetty to `12.0.9`.

With `12.0.9` we also need the `jetty-ee` jar to be included in the runtime-impl