### PR TITLE
fix bugs with DevAppServer and EE8

### DIFF
--- a/api_dev/src/main/java/com/google/appengine/tools/development/ResponseRewriterFilter.java
+++ b/api_dev/src/main/java/com/google/appengine/tools/development/ResponseRewriterFilter.java
@@ -23,19 +23,6 @@ import com.google.common.html.HtmlEscapers;
 import com.google.common.net.HttpHeaders;
 import org.eclipse.jetty.util.StringUtil;
 
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.WriteListener;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -50,6 +37,19 @@ import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.TimeZone;
 import java.util.Vector;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.WriteListener;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
 
 /**
  * A filter that rewrites the response headers and body from the user's

--- a/api_dev/src/main/java/com/google/appengine/tools/development/ResponseRewriterFilter.java
+++ b/api_dev/src/main/java/com/google/appengine/tools/development/ResponseRewriterFilter.java
@@ -21,7 +21,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.html.HtmlEscapers;
 import com.google.common.net.HttpHeaders;
-import org.eclipse.jetty.util.StringUtil;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -730,7 +729,7 @@ public class ResponseRewriterFilter implements Filter {
       checkNotCommitted();
       // This has to be re-implemented to avoid committing the response.
       setStatus(sc, msg);
-      setErrorBody(sc + " " + (StringUtil.isEmpty(msg) ? "" : HtmlEscapers.htmlEscaper().escape(msg)));
+      setErrorBody(sc + " " + (msg == null ? "" : HtmlEscapers.htmlEscaper().escape(msg)));
     }
 
     /** Sets the response body to an HTML page with an error message.

--- a/api_dev/src/main/java/com/google/appengine/tools/development/ResponseRewriterFilter.java
+++ b/api_dev/src/main/java/com/google/appengine/tools/development/ResponseRewriterFilter.java
@@ -21,6 +21,21 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.html.HtmlEscapers;
 import com.google.common.net.HttpHeaders;
+import org.eclipse.jetty.util.StringUtil;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.WriteListener;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -35,19 +50,6 @@ import java.util.Locale;
 import java.util.NoSuchElementException;
 import java.util.TimeZone;
 import java.util.Vector;
-import javax.servlet.Filter;
-import javax.servlet.FilterChain;
-import javax.servlet.FilterConfig;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
-import javax.servlet.WriteListener;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletRequestWrapper;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
 
 /**
  * A filter that rewrites the response headers and body from the user's
@@ -728,7 +730,7 @@ public class ResponseRewriterFilter implements Filter {
       checkNotCommitted();
       // This has to be re-implemented to avoid committing the response.
       setStatus(sc, msg);
-      setErrorBody(sc + " " + HtmlEscapers.htmlEscaper().escape(msg));
+      setErrorBody(sc + " " + (StringUtil.isEmpty(msg) ? "" : HtmlEscapers.htmlEscaper().escape(msg)));
     }
 
     /** Sets the response body to an HTML page with an error message.

--- a/api_dev/src/main/java/com/google/appengine/tools/development/ee10/ResponseRewriterFilter.java
+++ b/api_dev/src/main/java/com/google/appengine/tools/development/ee10/ResponseRewriterFilter.java
@@ -35,6 +35,8 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
+import org.eclipse.jetty.util.StringUtil;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -729,7 +731,7 @@ public class ResponseRewriterFilter implements Filter {
       checkNotCommitted();
       // This has to be re-implemented to avoid committing the response.
       super.sendError(sc, msg);
-      setErrorBody(sc + " " + HtmlEscapers.htmlEscaper().escape(msg));
+      setErrorBody(sc + " " + (StringUtil.isEmpty(msg) ? "" : HtmlEscapers.htmlEscaper().escape(msg)));
     }
 
     /** Sets the response body to an HTML page with an error message.

--- a/api_dev/src/main/java/com/google/appengine/tools/development/ee10/ResponseRewriterFilter.java
+++ b/api_dev/src/main/java/com/google/appengine/tools/development/ee10/ResponseRewriterFilter.java
@@ -35,7 +35,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletResponseWrapper;
-import org.eclipse.jetty.util.StringUtil;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -731,7 +730,7 @@ public class ResponseRewriterFilter implements Filter {
       checkNotCommitted();
       // This has to be re-implemented to avoid committing the response.
       setStatus(sc);
-      setErrorBody(sc + " " + (StringUtil.isEmpty(msg) ? "" : HtmlEscapers.htmlEscaper().escape(msg)));
+      setErrorBody(sc + " " + (msg == null ? "" : HtmlEscapers.htmlEscaper().escape(msg)));
     }
 
     /** Sets the response body to an HTML page with an error message.

--- a/api_dev/src/main/java/com/google/appengine/tools/development/ee10/ResponseRewriterFilter.java
+++ b/api_dev/src/main/java/com/google/appengine/tools/development/ee10/ResponseRewriterFilter.java
@@ -730,7 +730,7 @@ public class ResponseRewriterFilter implements Filter {
     public void sendError(int sc, String msg) throws IOException {
       checkNotCommitted();
       // This has to be re-implemented to avoid committing the response.
-      super.sendError(sc, msg);
+      setStatus(sc);
       setErrorBody(sc + " " + (StringUtil.isEmpty(msg) ? "" : HtmlEscapers.htmlEscaper().escape(msg)));
     }
 

--- a/api_dev/src/main/java/com/google/appengine/tools/info/Jetty12Sdk.java
+++ b/api_dev/src/main/java/com/google/appengine/tools/info/Jetty12Sdk.java
@@ -17,6 +17,7 @@
 package com.google.appengine.tools.info;
 
 import com.google.common.base.Joiner;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.net.URL;
@@ -191,6 +192,24 @@ class Jetty12Sdk extends AppengineSdk {
     return Collections.unmodifiableList(toURLs(getSharedJspLibFiles()));
   }
 
+  private File getJetty12Jar(String fileNamePattern) {
+    File path = new File(sdkRoot, JETTY12_HOME_LIB_PATH + File.separator);
+
+    if (!path.exists()) {
+      throw new IllegalArgumentException("Unable to find " + path.getAbsolutePath());
+    }
+    for (File f : listFiles(path)) {
+      if (f.getName().endsWith(".jar")) {
+        // All but CDI jar. All the tests are still passing without CDI that should not be exposed
+        // in our runtime (private Jetty dependency we do not want to expose to the customer).
+        if (f.getName().contains(fileNamePattern)) {
+          return f;
+        }
+      }
+    }
+    throw new IllegalArgumentException("Unable to find " + fileNamePattern + " at " + path.getAbsolutePath());
+  }
+
   private List<File> getJetty12Jars(String subDir) {
     File path = new File(sdkRoot, JETTY12_HOME_LIB_PATH + File.separator + subDir);
 
@@ -219,10 +238,12 @@ class Jetty12Sdk extends AppengineSdk {
     if (Boolean.getBoolean("appengine.use.EE10")) {
       List<File> lf = getJetty12Jars("ee10-apache-jsp");
       lf.addAll(getJetty12Jars("ee10-glassfish-jstl"));
+      lf.add(getJetty12Jar("ee10-servlet-"));
       return lf;
     }
     List<File> lf = getJetty12Jars("ee8-apache-jsp");
     lf.addAll(getJetty12Jars("ee8-glassfish-jstl"));
+    lf.add(getJetty12Jar("ee8-servlet-"));
     return lf;
   }
 

--- a/runtime/local_jetty12_ee10/src/main/java/com/google/appengine/tools/development/jetty/ee10/LocalResourceFileServlet.java
+++ b/runtime/local_jetty12_ee10/src/main/java/com/google/appengine/tools/development/jetty/ee10/LocalResourceFileServlet.java
@@ -24,18 +24,17 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.ee10.servlet.ServletMapping;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-
-import java.io.IOException;
-import java.net.MalformedURLException;
-import java.util.Objects;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * {@code ResourceFileServlet} is a copy of {@code org.mortbay.jetty.servlet.DefaultServlet} that

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
@@ -241,7 +241,6 @@ public class AppEngineWebAppContext extends WebAppContext {
     //  - Removed deprecated filters and servlets
     //  - Ensure known runtime filters/servlets are instantiated from this classloader
     //  - Ensure known runtime mappings exist.
-
     ServletHandler servletHandler = getServletHandler();
     TrimmedFilters trimmedFilters =
             new TrimmedFilters(

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -238,15 +238,13 @@ public class AppEngineWebAppContext extends WebAppContext {
     addEventListener(new TransactionCleanupListener(getClassLoader()));
   }
 
-
     @Override
     protected void startWebapp() throws Exception {
-
-          // This Listener doStart is called after the web.xml metadata has been resolved, so we can
-          // clean configuration here:
-          //  - Removed deprecated filters and servlets
-          //  - Ensure known runtime filters/servlets are instantiated from this classloader
-          //  - Ensure known runtime mappings exist.
+      // This Listener doStart is called after the web.xml metadata has been resolved, so we can
+      // clean configuration here:
+      //  - Removed deprecated filters and servlets
+      //  - Ensure known runtime filters/servlets are instantiated from this classloader
+      //  - Ensure known runtime mappings exist.
       ServletHandler servletHandler = getServletHandler();
       TrimmedFilters trimmedFilters =
               new TrimmedFilters(

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -238,64 +238,59 @@ public class AppEngineWebAppContext extends WebAppContext {
     addEventListener(new TransactionCleanupListener(getClassLoader()));
   }
 
+
     @Override
-    protected void startContext() throws Exception {
-    ServletHandler servletHandler = getServletHandler();
-      getServletHandler().addListener(new ListenerHolder() {
-        @Override
-        public void doStart() throws Exception {
+    protected void startWebapp() throws Exception {
 
           // This Listener doStart is called after the web.xml metadata has been resolved, so we can
           // clean configuration here:
           //  - Removed deprecated filters and servlets
           //  - Ensure known runtime filters/servlets are instantiated from this classloader
           //  - Ensure known runtime mappings exist.
-          setListener(new EventListener() {});
+      ServletHandler servletHandler = getServletHandler();
+      TrimmedFilters trimmedFilters =
+              new TrimmedFilters(
+                      servletHandler.getFilters(),
+                      servletHandler.getFilterMappings(),
+                      DEPRECATED_SERVLETS_FILTERS);
+      trimmedFilters.ensure(
+              "CloudSqlConnectionCleanupFilter", JdbcMySqlConnectionCleanupFilter.class, "/*");
 
-          TrimmedFilters trimmedFilters =
-                  new TrimmedFilters(
-                          servletHandler.getFilters(),
-                          servletHandler.getFilterMappings(),
-                          DEPRECATED_SERVLETS_FILTERS);
-          trimmedFilters.ensure(
-                  "CloudSqlConnectionCleanupFilter", JdbcMySqlConnectionCleanupFilter.class, "/*");
+      TrimmedServlets trimmedServlets =
+              new TrimmedServlets(
+                      servletHandler.getServlets(),
+                      servletHandler.getServletMappings(),
+                      DEPRECATED_SERVLETS_FILTERS);
+      trimmedServlets.ensure("_ah_warmup", WarmupServlet.class, "/_ah/warmup");
+      trimmedServlets.ensure(
+              "_ah_sessioncleanup", SessionCleanupServlet.class, "/_ah/sessioncleanup");
+      trimmedServlets.ensure(
+              "_ah_queue_deferred", DeferredTaskServlet.class, "/_ah/queue/__deferred__");
+      trimmedServlets.ensure("_ah_snapshot", SnapshotServlet.class, "/_ah/snapshot");
+      trimmedServlets.ensure("_ah_default", ResourceFileServlet.class, "/");
+      trimmedServlets.ensure("default", NamedDefaultServlet.class);
+      trimmedServlets.ensure("jsp", NamedJspServlet.class);
 
-          TrimmedServlets trimmedServlets =
-                  new TrimmedServlets(
-                          servletHandler.getServlets(),
-                          servletHandler.getServletMappings(),
-                          DEPRECATED_SERVLETS_FILTERS);
-          trimmedServlets.ensure("_ah_warmup", WarmupServlet.class, "/_ah/warmup");
-          trimmedServlets.ensure(
-                  "_ah_sessioncleanup", SessionCleanupServlet.class, "/_ah/sessioncleanup");
-          trimmedServlets.ensure(
-                  "_ah_queue_deferred", DeferredTaskServlet.class, "/_ah/queue/__deferred__");
-          trimmedServlets.ensure("_ah_snapshot", SnapshotServlet.class, "/_ah/snapshot");
-          trimmedServlets.ensure("_ah_default", ResourceFileServlet.class, "/");
-          trimmedServlets.ensure("default", NamedDefaultServlet.class);
-          trimmedServlets.ensure("jsp", NamedJspServlet.class);
+      trimmedServlets.instantiateJettyServlets();
+      trimmedFilters.instantiateJettyFilters();
+      instantiateJettyListeners();
 
-          trimmedServlets.instantiateJettyServlets();
-          trimmedFilters.instantiateJettyFilters();
-          instantiateJettyListeners();
+      servletHandler.setFilters(trimmedFilters.getHolders());
+      servletHandler.setFilterMappings(trimmedFilters.getMappings());
+      servletHandler.setServlets(trimmedServlets.getHolders());
+      servletHandler.setServletMappings(trimmedServlets.getMappings());
+      servletHandler.setAllowDuplicateMappings(true);
 
-          servletHandler.setFilters(trimmedFilters.getHolders());
-          servletHandler.setFilterMappings(trimmedFilters.getMappings());
-          servletHandler.setServlets(trimmedServlets.getHolders());
-          servletHandler.setServletMappings(trimmedServlets.getMappings());
-          servletHandler.setAllowDuplicateMappings(true);
+      // Protect deferred task queue with constraint
+      ConstraintSecurityHandler security = getChildHandlerByClass(ConstraintSecurityHandler.class);
+      ConstraintMapping cm = new ConstraintMapping();
+      cm.setConstraint(new ServletConstraint("deferred_queue", "admin"));
+      cm.setPathSpec("/_ah/queue/__deferred__");
+      security.addConstraintMapping(cm);
 
-          // Protect deferred task queue with constraint
-          ConstraintSecurityHandler security = getChildHandlerByClass(ConstraintSecurityHandler.class);
-          ConstraintMapping cm = new ConstraintMapping();
-          cm.setConstraint(new ServletConstraint("deferred_queue", "admin"));
-          cm.setPathSpec("/_ah/queue/__deferred__");
-          security.addConstraintMapping(cm);
-        }
-      });
 
-      // continue starting the webapp
-    super.startContext();
+    // continue starting the webapp
+    super.startWebapp();
   }
 
     @Override

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/proxy/UPRequestTranslator.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/proxy/UPRequestTranslator.java
@@ -16,34 +16,6 @@
 
 package com.google.apphosting.runtime.jetty.proxy;
 
-import com.google.apphosting.base.protos.AppinfoPb;
-import com.google.apphosting.base.protos.HttpPb;
-import com.google.apphosting.base.protos.HttpPb.HttpRequest;
-import com.google.apphosting.base.protos.HttpPb.ParsedHttpHeader;
-import com.google.apphosting.base.protos.RuntimePb;
-import com.google.apphosting.base.protos.RuntimePb.UPRequest;
-import com.google.apphosting.base.protos.TracePb.TraceContextProto;
-import com.google.apphosting.runtime.TraceContextHelper;
-import com.google.apphosting.runtime.jetty.AppInfoFactory;
-import com.google.common.base.Ascii;
-import com.google.common.base.Strings;
-import com.google.common.flogger.GoogleLogger;
-import com.google.common.html.HtmlEscapers;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.TextFormat;
-import org.eclipse.jetty.http.HttpField;
-import org.eclipse.jetty.http.HttpStatus;
-import org.eclipse.jetty.http.HttpURI;
-import org.eclipse.jetty.io.Content;
-import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
-import org.eclipse.jetty.util.Callback;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintWriter;
-
 import static com.google.apphosting.runtime.jetty.AppEngineConstants.DEFAULT_SECRET_KEY;
 import static com.google.apphosting.runtime.jetty.AppEngineConstants.IS_ADMIN_HEADER_VALUE;
 import static com.google.apphosting.runtime.jetty.AppEngineConstants.IS_TRUSTED;
@@ -74,6 +46,33 @@ import static com.google.apphosting.runtime.jetty.AppEngineConstants.X_FORWARDED
 import static com.google.apphosting.runtime.jetty.AppEngineConstants.X_GOOGLE_INTERNAL_PROFILER;
 import static com.google.apphosting.runtime.jetty.AppEngineConstants.X_GOOGLE_INTERNAL_SKIPADMINCHECK;
 import static com.google.apphosting.runtime.jetty.AppEngineConstants.X_GOOGLE_INTERNAL_SKIPADMINCHECK_UC;
+
+import com.google.apphosting.base.protos.AppinfoPb;
+import com.google.apphosting.base.protos.HttpPb;
+import com.google.apphosting.base.protos.HttpPb.HttpRequest;
+import com.google.apphosting.base.protos.HttpPb.ParsedHttpHeader;
+import com.google.apphosting.base.protos.RuntimePb;
+import com.google.apphosting.base.protos.RuntimePb.UPRequest;
+import com.google.apphosting.base.protos.TracePb.TraceContextProto;
+import com.google.apphosting.runtime.TraceContextHelper;
+import com.google.apphosting.runtime.jetty.AppInfoFactory;
+import com.google.common.base.Ascii;
+import com.google.common.base.Strings;
+import com.google.common.flogger.GoogleLogger;
+import com.google.common.html.HtmlEscapers;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.TextFormat;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
 
 /** Translates HttpServletRequest to the UPRequest proto, and vice versa for the response. */
 public class UPRequestTranslator {


### PR DESCRIPTION
- “IllegalStateException: Committed” after 403 Forbidden sent by DefaultServlet when directory listing is now allowed.
- Investigate and fix classloading issues not being able to load jetty-servlet classes from the web.xml configuration.
- Fix the redirect loop issue in the `LocalResourceFileServlet`.
- Use the `startWebApp()` method introduced in 12.0.8 for EE8 `AppEngineWebAppContext`.
- `NullPointerException` caused because the `HtmlEscaper` rejects null value for the error message from the `ResponseRewriteFilter`.
- Fix java.lang.IllegalStateException: Response has already been committed, because the `ResponseRewriterFilter.ResponseWrapper` was committing the response twice.
