### PR TITLE
Add tests for ServletContextListener for jetty94, EE8 and EE10

### DIFF
--- a/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/JavaRuntimeViaHttpBase.java
+++ b/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/JavaRuntimeViaHttpBase.java
@@ -404,7 +404,12 @@ public abstract class JavaRuntimeViaHttpBase {
   static void copyAppToDir(String appName, Path dir) throws IOException {
     Class<?> myClass = JavaRuntimeViaHttpBase.class;
     ClassLoader myClassLoader = myClass.getClassLoader();
-    String appPrefix = Reflection.getPackageName(myClass).replace('.', '/') + "/" + appName + "/";
+    String appPrefix;
+    if (appName.contains("/")) {
+      appPrefix = appName + "/";
+    } else {
+      appPrefix = Reflection.getPackageName(myClass).replace('.', '/') + "/" + appName + "/";
+    }
     String appEngineWebXmlResource = appPrefix + "WEB-INF/appengine-web.xml";
     URL appEngineWebXmlUrl = myClassLoader.getResource(appEngineWebXmlResource);
     assertWithMessage("Resource %s not found", appEngineWebXmlResource)

--- a/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/JavaRuntimeViaHttpBase.java
+++ b/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/JavaRuntimeViaHttpBase.java
@@ -404,12 +404,7 @@ public abstract class JavaRuntimeViaHttpBase {
   static void copyAppToDir(String appName, Path dir) throws IOException {
     Class<?> myClass = JavaRuntimeViaHttpBase.class;
     ClassLoader myClassLoader = myClass.getClassLoader();
-    String appPrefix;
-    if (appName.contains("/")) {
-      appPrefix = appName + "/";
-    } else {
-      appPrefix = Reflection.getPackageName(myClass).replace('.', '/') + "/" + appName + "/";
-    }
+    String appPrefix = Reflection.getPackageName(myClass).replace('.', '/') + "/" + appName + "/";
     String appEngineWebXmlResource = appPrefix + "WEB-INF/appengine-web.xml";
     URL appEngineWebXmlUrl = myClassLoader.getResource(appEngineWebXmlResource);
     assertWithMessage("Resource %s not found", appEngineWebXmlResource)

--- a/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/ServletContextListenerTest.java
+++ b/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/ServletContextListenerTest.java
@@ -92,7 +92,7 @@ public class ServletContextListenerTest extends JavaRuntimeViaHttpBase {
 
   @Before
   public void before() throws Exception {
-    String app = "servletcontextlistenerapp/" + environment;
+    String app = "com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/" + environment;
     copyAppToDir(app, temp.getRoot().toPath());
     httpClient.start();
     runtime = runtimeContext();

--- a/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/ServletContextListenerTest.java
+++ b/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/ServletContextListenerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.apphosting.runtime.jetty9;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentProvider;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.client.api.Result;
+import org.eclipse.jetty.client.util.ByteBufferContentProvider;
+import org.eclipse.jetty.client.util.DeferredContentProvider;
+import org.eclipse.jetty.client.util.InputStreamContentProvider;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.BufferUtil;
+import org.eclipse.jetty.util.Utf8StringBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.GZIPOutputStream;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+@RunWith(Parameterized.class)
+public class ServletContextListenerTest extends JavaRuntimeViaHttpBase {
+
+  @Parameterized.Parameters
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[][] {
+          {"jetty94", false},
+          {"ee8", false},
+          {"ee10", false},
+          {"ee8", true},
+          {"ee10", true},
+        });
+  }
+
+  @Rule public TemporaryFolder temp = new TemporaryFolder();
+  private final HttpClient httpClient = new HttpClient();
+  private final boolean httpMode;
+  private final String environment;
+  private RuntimeContext<?> runtime;
+
+  public ServletContextListenerTest(String environment, boolean httpMode) {
+    this.environment = environment;
+    this.httpMode = httpMode;
+    System.setProperty("appengine.use.HttpConnector", Boolean.toString(httpMode));
+  }
+
+  private RuntimeContext<?> runtimeContext() throws Exception {
+    RuntimeContext.Config<?> config =
+            RuntimeContext.Config.builder().setApplicationPath(temp.getRoot().toString()).build();
+    return RuntimeContext.create(config);
+  }
+
+  @Before
+  public void before() throws Exception {
+    String app = "servletcontextlistenerapp/" + environment;
+    copyAppToDir(app, temp.getRoot().toPath());
+    httpClient.start();
+    runtime = runtimeContext();
+    System.err.println("==== Using Environment: " + environment + " " + httpMode + " ====");
+  }
+
+  @After
+  public void after() throws Exception
+  {
+    httpClient.stop();
+    runtime.close();
+  }
+
+  @Test
+  public void testServletContextListener() throws Exception {
+    String url = runtime.jettyUrl("/");
+    CompletableFuture<Result> completionListener = new CompletableFuture<>();
+    Utf8StringBuilder contentReceived = new Utf8StringBuilder();
+    httpClient.newRequest(url).onResponseContentAsync((response, content, callback) -> {
+      contentReceived.append(content);
+      callback.succeeded();
+    }).send(completionListener::complete);
+
+    Result result = completionListener.get(5, TimeUnit.SECONDS);
+    assertThat(result.getResponse().getStatus(), equalTo(HttpStatus.OK_200));
+    assertThat(contentReceived.toString(), equalTo("ServletContextListenerAttribute: true"));
+  }
+}

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE10MainServlet.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE10MainServlet.java
@@ -1,0 +1,15 @@
+package com.google.apphosting.runtime.jetty9.servletcontextlistenerapp;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class EE10MainServlet  extends HttpServlet {
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    Object listenerAttribute = req.getServletContext().getAttribute("ServletContextListenerAttribute");
+    resp.getWriter().write("ServletContextListenerAttribute: " + listenerAttribute);
+  }
+}

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE10MainServlet.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE10MainServlet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.apphosting.runtime.jetty9.servletcontextlistenerapp;
 
 import jakarta.servlet.ServletException;

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE10ServletContextListener.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE10ServletContextListener.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.apphosting.runtime.jetty9.servletcontextlistenerapp;
+
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+
+public class EE10ServletContextListener implements ServletContextListener {
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        sce.getServletContext().setAttribute("ServletContextListenerAttribute", "true");
+    }
+}

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE8MainServlet.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE8MainServlet.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.google.apphosting.runtime.jetty9.servletcontextlistenerapp;
 
 import javax.servlet.ServletException;

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE8MainServlet.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE8MainServlet.java
@@ -1,0 +1,15 @@
+package com.google.apphosting.runtime.jetty9.servletcontextlistenerapp;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class EE8MainServlet extends HttpServlet {
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+    Object listenerAttribute = req.getServletContext().getAttribute("ServletContextListenerAttribute");
+    resp.getWriter().write("ServletContextListenerAttribute: " + listenerAttribute);
+  }
+}

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE8ServletContextListener.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/EE8ServletContextListener.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.apphosting.runtime.jetty9.servletcontextlistenerapp;
+
+import javax.servlet.ServletContextEvent;
+import javax.servlet.ServletContextListener;
+
+public class EE8ServletContextListener implements ServletContextListener {
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        sce.getServletContext().setAttribute("ServletContextListenerAttribute", "true");
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+    }
+}

--- a/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/ee10/WEB-INF/appengine-web.xml
+++ b/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/ee10/WEB-INF/appengine-web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <runtime>java21</runtime>
+  <application>sizelimithandler</application>
+  <version>1</version>
+  <threadsafe>true</threadsafe>
+  <system-properties>
+    <property name="appengine.use.EE8" value="false"/>
+    <property name="appengine.use.EE10" value="true"/>
+  </system-properties>
+</appengine-web-app>

--- a/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/ee10/WEB-INF/web.xml
+++ b/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/ee10/WEB-INF/web.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+           version="6.0">
+  <listener>
+    <listener-class>com.google.apphosting.runtime.jetty9.servletcontextlistenerapp.EE10ServletContextListener</listener-class>
+  </listener>
+
+  <servlet>
+    <servlet-name>MainServlet</servlet-name>
+    <servlet-class>com.google.apphosting.runtime.jetty9.servletcontextlistenerapp.EE10MainServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>MainServlet</servlet-name>
+    <url-pattern></url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/ee8/WEB-INF/appengine-web.xml
+++ b/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/ee8/WEB-INF/appengine-web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <runtime>java21</runtime>
+  <application>sizelimithandler</application>
+  <version>1</version>
+  <threadsafe>true</threadsafe>
+  <system-properties>
+    <property name="appengine.use.EE8" value="true"/>
+    <property name="appengine.use.EE10" value="false"/>
+  </system-properties>
+</appengine-web-app>

--- a/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/ee8/WEB-INF/web.xml
+++ b/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/ee8/WEB-INF/web.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <listener>
+    <listener-class>com.google.apphosting.runtime.jetty9.servletcontextlistenerapp.EE8ServletContextListener</listener-class>
+  </listener>
+
+  <servlet>
+    <servlet-name>MainServlet</servlet-name>
+    <servlet-class>com.google.apphosting.runtime.jetty9.servletcontextlistenerapp.EE8MainServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>MainServlet</servlet-name>
+    <url-pattern></url-pattern>
+  </servlet-mapping>
+</web-app>

--- a/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/jetty94/WEB-INF/appengine-web.xml
+++ b/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/jetty94/WEB-INF/appengine-web.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<appengine-web-app xmlns="http://appengine.google.com/ns/1.0">
+  <runtime>java21</runtime>
+  <application>sizelimithandler</application>
+  <version>1</version>
+  <threadsafe>true</threadsafe>
+  <system-properties>
+    <property name="appengine.use.EE8" value="false"/>
+    <property name="appengine.use.EE10" value="false"/>
+  </system-properties>
+</appengine-web-app>

--- a/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/jetty94/WEB-INF/web.xml
+++ b/runtime/testapps/src/main/resources/com/google/apphosting/runtime/jetty9/servletcontextlistenerapp/jetty94/WEB-INF/web.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<web-app xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+         version="4.0">
+  <listener>
+    <listener-class>com.google.apphosting.runtime.jetty9.servletcontextlistenerapp.EE8ServletContextListener</listener-class>
+  </listener>
+
+  <servlet>
+    <servlet-name>MainServlet</servlet-name>
+    <servlet-class>com.google.apphosting.runtime.jetty9.servletcontextlistenerapp.EE8MainServlet</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>MainServlet</servlet-name>
+    <url-pattern></url-pattern>
+  </servlet-mapping>
+</web-app>


### PR DESCRIPTION
add tests for ServletContextListener to prevent any further regressions
The test is parameterized over jetty94, EE8 and EE10 and also the new mode to bypass RPC