### PR TITLE
Update Jetty to 12.0.10 and fix issues with jetty-dir.css in JettyServletEngineAdapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jetty.version>9.4.54.v20240208</jetty.version>
-    <jetty12.version>12.0.9</jetty12.version>
+    <jetty12.version>12.0.10</jetty12.version>
     <slf4j.version>2.0.13</slf4j.version>
     <distributionManagement.snapshot.url>https://oss.sonatype.org/content/repositories/google-snapshots/</distributionManagement.snapshot.url>
     <distributionManagement.snapshot.id>sonatype-nexus-snapshots</distributionManagement.snapshot.id>

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
@@ -110,12 +110,7 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
       threadPool.setVirtualThreadsExecutor(VirtualThreads.getDefaultVirtualThreadsExecutor());
       logger.atInfo().log("Configuring Appengine web server virtual threads.");
     }
-    // The server.getDefaultStyleSheet() returns is returning null because of some classloading
-    // issue,
-    // so we get the StyleSheet here to ensure it returns the correct value.
-    Resource styleSheet =
-        ResourceFactory.root()
-            .newResource(getClass().getClassLoader().getResource("jetty-dir.css"));
+
     server =
         new Server(threadPool) {
           @Override
@@ -125,7 +120,16 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
 
           @Override
           public Resource getDefaultStyleSheet() {
-            return styleSheet;
+            // TODO: this is a workaround for https://github.com/jetty/jetty.project/issues/11873
+            return ResourceFactory.of(this)
+                    .newResource("/org/eclipse/jetty/server/jetty-dir.css");
+          }
+
+          @Override
+          public Resource getDefaultFavicon() {
+            // TODO: this is a workaround for https://github.com/jetty/jetty.project/issues/11873
+            return ResourceFactory.of(this)
+                    .newResource("/org/eclipse/jetty/server/favicon.ico");
           }
         };
     rpcConnector =


### PR DESCRIPTION
Update to Jetty `12.0.10`.

Update workaround for `jetty-dir.css` not being found, and link to issue to fix on the Jetty repository.
see https://github.com/jetty/jetty.project/issues/11873