### PR TITLE
Issue #241 - fix deferred authentication for Java21 EE10 runtime

### DIFF
--- a/shared_sdk_jetty12/src/main/java/com/google/apphosting/runtime/jetty/EE10AppEngineAuthentication.java
+++ b/shared_sdk_jetty12/src/main/java/com/google/apphosting/runtime/jetty/EE10AppEngineAuthentication.java
@@ -179,10 +179,6 @@ public class EE10AppEngineAuthentication {
         throw new ServerAuthException("validateRequest called with null response!!!");
       }
 
-      if (AuthenticationState.Deferred.isDeferred(res)) {
-        return null;
-      }
-
       try {
         UserService userService = UserServiceFactory.getUserService();
         // If the user is authenticated already, just create a
@@ -193,6 +189,10 @@ public class EE10AppEngineAuthentication {
           if (user != null) {
             return new UserAuthenticationSucceeded(getAuthenticationType(), user);
           }
+        }
+
+        if (AuthenticationState.Deferred.isDeferred(res)) {
+          return null;
         }
 
         try {


### PR DESCRIPTION
closes #241

If `request.getUserPrincipal()` was being called on a request with deferred authentication, then authentication was failing.

This is because the `isDeferred` check in `EE10AppEngineAuthentication` was in the wrong place.