### PR TITLE
Initialize HttpChannel in DelegateConnection to create Violation Listeners

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/internal/DelegateConnection.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/delegate/internal/DelegateConnection.java
@@ -118,6 +118,7 @@ public class DelegateConnection implements Connection {
           new DelegateConnectionMetadata(_endpoint, this, _connector);
       HttpChannelState httpChannel = new HttpChannelState(connectionMetaData);
       httpChannel.setHttpStream(new DelegateHttpStream(_endpoint, this, httpChannel));
+      httpChannel.initialize();
 
       // Generate the Request MetaData.
       String method = delegateExchange.getMethod();


### PR DESCRIPTION
The `DelegateConnection` is missing a call to initialize the `HttpChannel` this is necessary to create the violation listeners.
Currently violations reported will cause NPE as the listener has not been set.