### PR TITLE
ensure flushOnResponseCommit is true for session caches

### DIFF
--- a/shared_sdk_jetty12/src/main/java/com/google/apphosting/runtime/jetty/EE10SessionManagerHandler.java
+++ b/shared_sdk_jetty12/src/main/java/com/google/apphosting/runtime/jetty/EE10SessionManagerHandler.java
@@ -164,6 +164,7 @@ public class EE10SessionManagerHandler {
       super(handler);
       // Saves a call to the SessionDataStore.
       setSaveOnCreate(false);
+      setFlushOnResponseCommit(true);
       setRemoveUnloadableSessions(false);
     }
 
@@ -264,6 +265,7 @@ public class EE10SessionManagerHandler {
     AppEngineSessionCache(SessionHandler handler) {
       super(handler);
       setSaveOnCreate(true);
+      setFlushOnResponseCommit(true);
     }
 
     @Override

--- a/shared_sdk_jetty12/src/main/java/com/google/apphosting/runtime/jetty/SessionManagerHandler.java
+++ b/shared_sdk_jetty12/src/main/java/com/google/apphosting/runtime/jetty/SessionManagerHandler.java
@@ -164,6 +164,7 @@ public class SessionManagerHandler {
       super(handler.getSessionManager());
       // Saves a call to the SessionDataStore.
       setSaveOnCreate(false);
+      setFlushOnResponseCommit(true);
       setRemoveUnloadableSessions(false);
     }
 
@@ -264,6 +265,7 @@ public class SessionManagerHandler {
     AppEngineSessionCache(SessionHandler handler) {
       super(handler.getSessionManager());
       setSaveOnCreate(true);
+      setFlushOnResponseCommit(true);
     }
 
     @Override

--- a/shared_sdk_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/SessionManagerHandler.java
+++ b/shared_sdk_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/SessionManagerHandler.java
@@ -167,6 +167,7 @@ public class SessionManagerHandler {
       super(handler);
       // Saves a call to the SessionDataStore.
       setSaveOnCreate(false);
+      setFlushOnResponseCommit(true);
       setRemoveUnloadableSessions(false);
     }
 
@@ -278,6 +279,7 @@ public class SessionManagerHandler {
     AppEngineSessionCache(SessionHandler handler) {
       super(handler);
       setSaveOnCreate(true);
+      setFlushOnResponseCommit(true);
     }
 
     @Override


### PR DESCRIPTION
Ensure that the `FlushOnResponseCommit` setting is set to `true` for the GAE `SessionCache`s.
This configuration was suggested by @janbartel.

> If true, a dirty session will be written to the SessionDataStore just before a response is returned to the client. This ensures that subsequent requests to either the same node or a different node see the changed session data.