### PR TITLE
lazy initialization of AppEngineWebAppContext for HttpConnector mode

### DIFF
--- a/runtime/impl/src/main/java/com/google/apphosting/runtime/ServletEngineAdapter.java
+++ b/runtime/impl/src/main/java/com/google/apphosting/runtime/ServletEngineAdapter.java
@@ -67,6 +67,7 @@ public interface ServletEngineAdapter extends UPRequestHandler {
    * stored, if sessions are enabled. This method must be invoked after
    * {@link #start}.
    */
+  @Deprecated
   void setSessionStoreFactory(SessionStoreFactory factory);
 
   /**

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/JettyServletEngineAdapter.java
@@ -117,18 +117,6 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
           public InvocationType getInvocationType() {
             return InvocationType.BLOCKING;
           }
-
-          @Override
-          public Resource getDefaultStyleSheet() {
-            // TODO: this is a workaround for https://github.com/jetty/jetty.project/issues/11873
-            return ResourceFactory.of(this).newResource("/org/eclipse/jetty/server/jetty-dir.css");
-          }
-
-          @Override
-          public Resource getDefaultFavicon() {
-            // TODO: this is a workaround for https://github.com/jetty/jetty.project/issues/11873
-            return ResourceFactory.of(this).newResource("/org/eclipse/jetty/server/favicon.ico");
-          }
         };
     rpcConnector =
         new DelegateConnector(server, "RPC") {
@@ -168,7 +156,6 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
         evaluationRuntimeServerInterface.addAppVersion(context, appinfo);
         context.getResponse();
         appVersionKey = AppVersionKey.fromAppInfo(appinfo);
-        appVersionHandler.ensureHandler(appVersionKey);
       } catch (Exception e) {
         throw new IllegalStateException(e);
       }
@@ -219,15 +206,9 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
     appVersionHandler.removeAppVersion(appVersion.getKey());
   }
 
-  /**
-   * Sets the {@link com.google.apphosting.runtime.SessionStoreFactory} that will be used to create
-   * the list of {@link com.google.apphosting.runtime.SessionStore SessionStores} to which the HTTP
-   * Session will be stored, if sessions are enabled. This method must be invoked after {@link
-   * #start(String, Config)}.
-   */
   @Override
   public void setSessionStoreFactory(com.google.apphosting.runtime.SessionStoreFactory factory) {
-    appVersionHandler.setSessionStoreFactory(factory);
+    // No op with the new Jetty Session management.
   }
 
   @Override

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/http/JettyHttpHandler.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/http/JettyHttpHandler.java
@@ -29,6 +29,7 @@ import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.runtime.BackgroundRequestCoordinator;
 import com.google.apphosting.runtime.LocalRpcContext;
 import com.google.apphosting.runtime.RequestManager;
+import com.google.apphosting.runtime.RequestRunner;
 import com.google.apphosting.runtime.RequestRunner.EagerRunner;
 import com.google.apphosting.runtime.ResponseAPIData;
 import com.google.apphosting.runtime.ServletEngineAdapter;
@@ -41,6 +42,7 @@ import java.util.concurrent.TimeoutException;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.Callback;
 

--- a/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/AppVersionHandlerMap.java
+++ b/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/AppVersionHandlerMap.java
@@ -19,7 +19,6 @@ package com.google.apphosting.runtime.jetty9;
 import com.google.apphosting.base.AppVersionKey;
 import com.google.apphosting.runtime.AppEngineConstants;
 import com.google.apphosting.runtime.AppVersion;
-import com.google.apphosting.runtime.SessionStoreFactory;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -57,16 +56,6 @@ public class AppVersionHandlerMap extends AbstractHandlerContainer {
 
   public void removeAppVersion(AppVersionKey appVersionKey) {
     appVersionMap.remove(appVersionKey);
-  }
-
-  /**
-   * Sets the {@link SessionStoreFactory} that will be used for generating the list of {@link
-   * SessionStore SessionStores} that will be passed to {@link SessionManager} for apps for which
-   * sessions are enabled. This setter is currently used only for testing purposes. Normally the
-   * default factory is sufficient.
-   */
-  public void setSessionStoreFactory(SessionStoreFactory factory) {
-    // No op with the new Jetty Session management.
   }
 
   /**

--- a/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyHttpHandler.java
+++ b/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyHttpHandler.java
@@ -30,6 +30,7 @@ import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.runtime.BackgroundRequestCoordinator;
 import com.google.apphosting.runtime.LocalRpcContext;
 import com.google.apphosting.runtime.RequestManager;
+import com.google.apphosting.runtime.RequestRunner;
 import com.google.apphosting.runtime.RequestRunner.EagerRunner;
 import com.google.apphosting.runtime.ResponseAPIData;
 import com.google.apphosting.runtime.ServletEngineAdapter;
@@ -42,7 +43,9 @@ import java.util.concurrent.TimeoutException;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.HandlerWrapper;
 
 /**

--- a/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyServletEngineAdapter.java
+++ b/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyServletEngineAdapter.java
@@ -141,7 +141,6 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
         if (Boolean.getBoolean(HTTP_CONNECTOR_MODE)) {
           logger.atInfo().log("Using HTTP_CONNECTOR_MODE to bypass RPC");
           appVersionKey = AppVersionKey.fromAppInfo(appinfo);
-          Handler unused2 = appVersionHandlerMap.getHandler(appVersionKey);
           JettyHttpProxy.insertHandlers(server);
           AppVersion appVersion = appVersionHandlerMap.getAppVersion(appVersionKey);
           server.insertHandler(
@@ -195,15 +194,9 @@ public class JettyServletEngineAdapter implements ServletEngineAdapter {
     appVersionHandlerMap.removeAppVersion(appVersion.getKey());
   }
 
-  /**
-   * Sets the {@link com.google.apphosting.runtime.SessionStoreFactory} that will be used to create
-   * the list of {@link com.google.apphosting.runtime.SessionStore SessionStores} to which the HTTP
-   * Session will be stored, if sessions are enabled. This method must be invoked after {@link
-   * #start(String, Config)}.
-   */
   @Override
   public void setSessionStoreFactory(SessionStoreFactory factory) {
-    appVersionHandlerMap.setSessionStoreFactory(factory);
+    // No op with the new Jetty Session management.
   }
 
   @Override


### PR DESCRIPTION
- The `AppEngineWebAppContext` should not be created until we are in the scope of the first request so the `ApiProxy.Environment` is set for initialization. This is also how it is currently done in the RPC mode but early initialization was done for HTTP mode.
- Deprecate `ServletEngineAdapter.setSessionStoreFactory` because it is not used or implemented anymore.
- Remove workaround for issue https://github.com/jetty/jetty.project/issues/11873