### PR TITLE
Update README.md to correct groupId for jakarta.servlet-api dependency.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,11 +92,11 @@ Source code for all public APIs for com.google.appengine.api.* packages.
             <version>2.0.31</version><!-- or later-->
         </dependency>
         <dependency>
-          <groupId>javax.servlet</groupId>
-           <artifactId>jakarta.servlet-api</artifactId>
+          <groupId>jakarta.servlet</groupId>
+          <artifactId>jakarta.servlet-api</artifactId>
           <version>6.0.0</version>
           <scope>provided</scope>
-    </dependency>
+        </dependency>
     ...
     ```
 


### PR DESCRIPTION
The `jakarta.servlet-api` (`6.0.0`) dependency example in the README currently lists the outdated `javax.servlet` group. This pull request updates the `groupId` to the correct `jakarta.servlet` namespace, aligning with the changes introduced in the Jakarta EE transition.