### PR TITLE
ensure callback is completed in the EE10 NullErrorHandler

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/EE10AppVersionHandlerFactory.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/EE10AppVersionHandlerFactory.java
@@ -275,6 +275,7 @@ public class EE10AppVersionHandlerFactory implements AppVersionHandlerFactory {
               // or let the Runtime generate the default error page
               // TODO: an invalid html dispatch (404) will mask the exception
               request.setAttribute(ERROR_PAGE_HANDLED, errorPage);
+              callback.succeeded();
               return;
             } else {
               logger.atWarning().log("No error page %s", errorPage);
@@ -308,7 +309,7 @@ public class EE10AppVersionHandlerFactory implements AppVersionHandlerFactory {
       }
       // If we got this far and *did* have an exception, it will be
       // retrieved and thrown at the end of JettyServletEngineAdapter#serviceRequest.
-      throw new IllegalStateException(error);
+      callback.failed(new IllegalStateException(error));
     }
   }
 }

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/EE10AppVersionHandlerFactory.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/EE10AppVersionHandlerFactory.java
@@ -309,7 +309,7 @@ public class EE10AppVersionHandlerFactory implements AppVersionHandlerFactory {
       }
       // If we got this far and *did* have an exception, it will be
       // retrieved and thrown at the end of JettyServletEngineAdapter#serviceRequest.
-      callback.failed(new IllegalStateException(error));
+      throw new IllegalStateException(error);
     }
   }
 }


### PR DESCRIPTION
The callback was not completed in the EE10 `NullErrorHandler` causing the responses to not be completed when dispatching to an error page.

@maigovannon I have tested this manually with the reproducer example from https://github.com/GoogleCloudPlatform/appengine-java-standard/issues/316. But writing tests for this might be a good opportunity for your team to get some more hands on experience with the appengine-java-standard code base.