### PR TITLE
Issue #325 - fixes and testing for HttpServletRequest getServerName

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/http/JettyRequestAPIData.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/http/JettyRequestAPIData.java
@@ -124,7 +124,8 @@ public class JettyRequestAPIData implements RequestAPIData {
 
     HttpFields.Mutable fields = HttpFields.build();
     for (HttpField field : request.getHeaders()) {
-      // If it has a HttpHeader it is one of the standard headers so won't match any appengine specific header.
+      // If it has a HttpHeader it is one of the standard headers so won't match any appengine
+      // specific header.
       if (field.getHeader() != null) {
         fields.add(field);
         continue;

--- a/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyRequestAPIData.java
+++ b/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyRequestAPIData.java
@@ -67,12 +67,12 @@ import java.util.Objects;
 import java.util.stream.Stream;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
-
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.HostPort;
 
 /**
  * Implementation for the {@link RequestAPIData} to allow for the Jetty {@link Request} to be used
@@ -286,7 +286,7 @@ public class JettyRequestAPIData implements RequestAPIData {
       traceContext = TraceContextProto.getDefaultInstance();
     }
 
-    String finalUserIp = userIp;
+    String normalizeUserIp = HostPort.normalizeHost(userIp);
     this.httpServletRequest =
         new HttpServletRequestWrapper(httpServletRequest) {
 
@@ -332,17 +332,12 @@ public class JettyRequestAPIData implements RequestAPIData {
 
           @Override
           public String getRemoteAddr() {
-            return finalUserIp;
-          }
-
-          @Override
-          public String getServerName() {
-            return UNSPECIFIED_IP;
+            return normalizeUserIp;
           }
 
           @Override
           public String getRemoteHost() {
-            return finalUserIp;
+            return normalizeUserIp;
           }
 
           @Override

--- a/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyRequestAPIData.java
+++ b/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyRequestAPIData.java
@@ -51,6 +51,7 @@ import static com.google.apphosting.runtime.AppEngineConstants.X_CLOUD_TRACE_CON
 import static com.google.apphosting.runtime.AppEngineConstants.X_FORWARDED_PROTO;
 import static com.google.apphosting.runtime.AppEngineConstants.X_GOOGLE_INTERNAL_PROFILER;
 import static com.google.apphosting.runtime.AppEngineConstants.X_GOOGLE_INTERNAL_SKIPADMINCHECK;
+import static com.google.apphosting.runtime.jetty9.RpcConnection.NORMALIZE_INET_ADDR;
 
 import com.google.apphosting.base.protos.HttpPb;
 import com.google.apphosting.base.protos.RuntimePb;
@@ -286,7 +287,7 @@ public class JettyRequestAPIData implements RequestAPIData {
       traceContext = TraceContextProto.getDefaultInstance();
     }
 
-    String normalizeUserIp = HostPort.normalizeHost(userIp);
+    String finalUserIp = NORMALIZE_INET_ADDR ? HostPort.normalizeHost(userIp) : userIp;
     this.httpServletRequest =
         new HttpServletRequestWrapper(httpServletRequest) {
 
@@ -332,12 +333,12 @@ public class JettyRequestAPIData implements RequestAPIData {
 
           @Override
           public String getRemoteAddr() {
-            return normalizeUserIp;
+            return finalUserIp;
           }
 
           @Override
           public String getRemoteHost() {
-            return normalizeUserIp;
+            return finalUserIp;
           }
 
           @Override

--- a/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyRequestAPIData.java
+++ b/runtime/runtime_impl_jetty9/src/main/java/com/google/apphosting/runtime/jetty9/JettyRequestAPIData.java
@@ -129,7 +129,8 @@ public class JettyRequestAPIData implements RequestAPIData {
 
     HttpFields fields = new HttpFields();
     for (HttpField field : request.getHttpFields()) {
-      // If it has a HttpHeader it is one of the standard headers so won't match any appengine specific header.
+      // If it has a HttpHeader it is one of the standard headers so won't match any appengine
+      // specific header.
       if (field.getHeader() != null) {
         fields.add(field);
         continue;

--- a/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/RemoteAddressTest.java
+++ b/runtime/test/src/test/java/com/google/apphosting/runtime/jetty9/RemoteAddressTest.java
@@ -82,7 +82,9 @@ public class RemoteAddressTest extends JavaRuntimeViaHttpBase {
 
   @Test
   public void testWithHostHeader() throws Exception {
-    ContentResponse response = httpClient.newRequest(url)
+    ContentResponse response =
+        httpClient
+            .newRequest(url)
             .header("Host", "foobar:1234")
             .header("X-AppEngine-User-IP", "203.0.113.1")
             .send();
@@ -101,21 +103,24 @@ public class RemoteAddressTest extends JavaRuntimeViaHttpBase {
 
   @Test
   public void testWithIPv6() throws Exception {
-        // Test the host header to be IPv6 with a port.
-        ContentResponse response = httpClient.newRequest(url)
-                .header("Host", "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:1234")
-                .header("X-AppEngine-User-IP", "203.0.113.1")
-                .send();
-        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
-        String contentReceived = response.getContentAsString();
-        assertThat(contentReceived, containsString("getRemoteAddr: 203.0.113.1"));
-        assertThat(contentReceived, containsString("getRemoteHost: 203.0.113.1"));
-        assertThat(contentReceived, containsString("getRemotePort: 0"));
-        assertThat(contentReceived, containsString("getLocalAddr: 0.0.0.0"));
-        assertThat(contentReceived, containsString("getLocalName: 0.0.0.0"));
-        assertThat(contentReceived, containsString("getLocalPort: 0"));
-        assertThat(contentReceived, containsString("getServerName: [2001:db8:85a3:8d3:1319:8a2e:370:7348]"));
-        assertThat(contentReceived, containsString("getServerPort: 1234"));
+    // Test the host header to be IPv6 with a port.
+    ContentResponse response =
+        httpClient
+            .newRequest(url)
+            .header("Host", "[2001:db8:85a3:8d3:1319:8a2e:370:7348]:1234")
+            .header("X-AppEngine-User-IP", "203.0.113.1")
+            .send();
+    assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+    String contentReceived = response.getContentAsString();
+    assertThat(contentReceived, containsString("getRemoteAddr: 203.0.113.1"));
+    assertThat(contentReceived, containsString("getRemoteHost: 203.0.113.1"));
+    assertThat(contentReceived, containsString("getRemotePort: 0"));
+    assertThat(contentReceived, containsString("getLocalAddr: 0.0.0.0"));
+    assertThat(contentReceived, containsString("getLocalName: 0.0.0.0"));
+    assertThat(contentReceived, containsString("getLocalPort: 0"));
+    assertThat(
+        contentReceived, containsString("getServerName: [2001:db8:85a3:8d3:1319:8a2e:370:7348]"));
+    assertThat(contentReceived, containsString("getServerPort: 1234"));
 
     // Test the user IP to be IPv6 with a port.
     response =
@@ -127,13 +132,17 @@ public class RemoteAddressTest extends JavaRuntimeViaHttpBase {
     assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
     contentReceived = response.getContentAsString();
     if ("jetty94".equals(environment)) {
-      assertThat(contentReceived, containsString("getRemoteAddr: [2001:db8:85a3:8d3:1319:8a2e:370:7348]"));
-      assertThat(contentReceived, containsString("getRemoteHost: [2001:db8:85a3:8d3:1319:8a2e:370:7348]"));
+      assertThat(
+          contentReceived, containsString("getRemoteAddr: [2001:db8:85a3:8d3:1319:8a2e:370:7348]"));
+      assertThat(
+          contentReceived, containsString("getRemoteHost: [2001:db8:85a3:8d3:1319:8a2e:370:7348]"));
     } else {
       // The correct behaviour for getRemoteAddr and getRemoteHost is to not include []
       // because they return raw IP/hostname and not URI-formatted addresses.
-      assertThat(contentReceived, containsString("getRemoteAddr: 2001:db8:85a3:8d3:1319:8a2e:370:7348"));
-      assertThat(contentReceived, containsString("getRemoteHost: 2001:db8:85a3:8d3:1319:8a2e:370:7348"));
+      assertThat(
+          contentReceived, containsString("getRemoteAddr: 2001:db8:85a3:8d3:1319:8a2e:370:7348"));
+      assertThat(
+          contentReceived, containsString("getRemoteHost: 2001:db8:85a3:8d3:1319:8a2e:370:7348"));
     }
     assertThat(contentReceived, containsString("getRemotePort: 0"));
     assertThat(contentReceived, containsString("getLocalAddr: 0.0.0.0"));
@@ -145,9 +154,9 @@ public class RemoteAddressTest extends JavaRuntimeViaHttpBase {
 
   @Test
   public void testWithoutHostHeader() throws Exception {
-    String url = runtime.jettyUrl("/");
-
-    ContentResponse response = httpClient.newRequest(url)
+    ContentResponse response =
+        httpClient
+            .newRequest(url)
             .version(HttpVersion.HTTP_1_0)
             .header("X-AppEngine-User-IP", "203.0.113.1")
             .onRequestHeaders(request -> request.getHeaders().remove("Host"))
@@ -190,7 +199,6 @@ public class RemoteAddressTest extends JavaRuntimeViaHttpBase {
     assertThat(contentReceived, containsString("getServerName: foobar"));
     assertThat(contentReceived, containsString("getServerPort: 1234"));
   }
-
 
   private RuntimeContext<?> runtimeContext() throws Exception {
     RuntimeContext.Config<?> config =

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/remoteaddrapp/EE10RemoteAddrServlet.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/remoteaddrapp/EE10RemoteAddrServlet.java
@@ -28,10 +28,13 @@ public class EE10RemoteAddrServlet extends HttpServlet {
     resp.setContentType("text/plain");
     PrintWriter writer = resp.getWriter();
     writer.println("getRemoteAddr: " + req.getRemoteAddr());
-    writer.println("getLocalAddr: " + req.getLocalAddr());
-    writer.println("getServerPort: " + req.getServerPort());
+    writer.println("getRemoteHost: " + req.getRemoteHost());
     writer.println("getRemotePort: " + req.getRemotePort());
+    writer.println("getLocalAddr: " + req.getLocalAddr());
+    writer.println("getLocalName: " + req.getLocalName());
     writer.println("getLocalPort: " + req.getLocalPort());
     writer.println("getServerName: " + req.getServerName());
+    writer.println("getServerPort: " + req.getServerPort());
+
   }
 }

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/remoteaddrapp/EE10RemoteAddrServlet.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/remoteaddrapp/EE10RemoteAddrServlet.java
@@ -35,6 +35,5 @@ public class EE10RemoteAddrServlet extends HttpServlet {
     writer.println("getLocalPort: " + req.getLocalPort());
     writer.println("getServerName: " + req.getServerName());
     writer.println("getServerPort: " + req.getServerPort());
-
   }
 }

--- a/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/remoteaddrapp/EE8RemoteAddrServlet.java
+++ b/runtime/testapps/src/main/java/com/google/apphosting/runtime/jetty9/remoteaddrapp/EE8RemoteAddrServlet.java
@@ -28,10 +28,12 @@ public class EE8RemoteAddrServlet extends HttpServlet {
     resp.setContentType("text/plain");
     PrintWriter writer = resp.getWriter();
     writer.println("getRemoteAddr: " + req.getRemoteAddr());
-    writer.println("getLocalAddr: " + req.getLocalAddr());
-    writer.println("getServerPort: " + req.getServerPort());
+    writer.println("getRemoteHost: " + req.getRemoteHost());
     writer.println("getRemotePort: " + req.getRemotePort());
+    writer.println("getLocalAddr: " + req.getLocalAddr());
+    writer.println("getLocalName: " + req.getLocalName());
     writer.println("getLocalPort: " + req.getLocalPort());
     writer.println("getServerName: " + req.getServerName());
+    writer.println("getServerPort: " + req.getServerPort());
   }
 }


### PR DESCRIPTION
Fixes for #325

- Remove the `getServerName` override in the `HttpServletRequest` to allow it to get the serverName from the request metadata.
- improve testing in `RemoteAddressTest` with additional test cases with `Host` header, and test all relevant methods on `HttpServletRequest`.