### PR TITLE
Fix redirect loop bug in ResourceFileServlet

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/ResourceFileServlet.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/ResourceFileServlet.java
@@ -16,8 +16,8 @@
 
 package com.google.apphosting.runtime.jetty.ee8;
 
-import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.runtime.AppEngineConstants;
+import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.utils.config.AppYaml;
 import com.google.common.base.Ascii;
 import com.google.common.flogger.GoogleLogger;
@@ -30,8 +30,9 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee8.nested.ContextHandler;
+import org.eclipse.jetty.ee8.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee8.servlet.ServletHandler;
-import org.eclipse.jetty.http.pathmap.MappedResource;
+import org.eclipse.jetty.ee8.servlet.ServletMapping;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
@@ -57,8 +58,9 @@ public class ResourceFileServlet extends HttpServlet {
   private Resource resourceBase;
   private String[] welcomeFiles;
   private FileSender fSender;
-  ContextHandler chandler;
+  ServletContextHandler chandler;
   ServletContext context;
+  String defaultServletName;
 
   /**
    * Initialize the servlet by extracting some useful configuration data from the current {@link
@@ -69,7 +71,7 @@ public class ResourceFileServlet extends HttpServlet {
     context = getServletContext();
     AppVersion appVersion =
         (AppVersion) context.getAttribute(AppEngineConstants.APP_VERSION_CONTEXT_ATTR);
-    chandler = ContextHandler.getContextHandler(context);
+    chandler = ServletContextHandler.getServletContextHandler(context);
 
     AppYaml appYaml =
         (AppYaml) chandler.getServer().getAttribute(AppEngineConstants.APP_YAML_ATTRIBUTE_TARGET);
@@ -77,6 +79,12 @@ public class ResourceFileServlet extends HttpServlet {
     // AFAICT, there is no real API to retrieve this information, so
     // we access Jetty's internal state.
     welcomeFiles = chandler.getWelcomeFiles();
+
+    ServletMapping servletMapping = chandler.getServletHandler().getServletMapping("/");
+    if (servletMapping == null) {
+      throw new ServletException("No servlet mapping found");
+    }
+    defaultServletName = servletMapping.getServletName();
 
     try {
       // TODO: review use of root factory.
@@ -254,13 +262,12 @@ public class ResourceFileServlet extends HttpServlet {
         (AppVersion) getServletContext().getAttribute(AppEngineConstants.APP_VERSION_CONTEXT_ATTR);
     ServletHandler handler = chandler.getChildHandlerByClass(ServletHandler.class);
 
-    MappedResource<ServletHandler.MappedServlet> defaultEntry = handler.getHolderEntry("/");
-
     for (String welcomeName : welcomeFiles) {
       String welcomePath = path + welcomeName;
       String relativePath = welcomePath.substring(1);
 
-      if (!Objects.equals(handler.getHolderEntry(welcomePath), defaultEntry)) {
+      ServletHandler.MappedServlet mappedServlet = handler.getMappedServlet(welcomePath);
+      if (!Objects.equals(mappedServlet.getServletHolder().getName(), defaultServletName)) {
         // It's a path mapped to a servlet.  Forward to it.
         RequestDispatcher dispatcher = request.getRequestDispatcher(path + welcomeName);
         return serveWelcomeFileAsForward(dispatcher, included, request, response);


### PR DESCRIPTION
I ran into a bug in `ResourceFileServlet`, where trying to access a static file puts you in a redirect loop resulting in a URI looking like this:

`http://localhost:8080/hello.txt/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/index.html/`

The call to `getHolderEntry("/")` was finding the context root mapping instead of the default mapping, this was causing an infinite redirect bug. This PR changes this to use `getServletMapping("/")` which tests by pathSpec.