### PR TITLE
Allow null resource base in ResourceFileServlet with Jetty 12

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/ResourceFileServlet.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/ResourceFileServlet.java
@@ -16,8 +16,8 @@
 
 package com.google.apphosting.runtime.jetty.ee10;
 
-import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.runtime.AppEngineConstants;
+import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.utils.config.AppYaml;
 import com.google.common.base.Ascii;
 import com.google.common.flogger.GoogleLogger;
@@ -27,6 +27,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Objects;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.ServletHandler;
 import org.eclipse.jetty.ee10.servlet.ServletMapping;
@@ -35,9 +38,6 @@ import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
-
-import java.io.IOException;
-import java.util.Objects;
 
 /**
  * {@code ResourceFileServlet} is a copy of {@code org.mortbay.jetty.servlet.DefaultServlet} that
@@ -88,9 +88,8 @@ public class ResourceFileServlet extends HttpServlet {
     defaultServletName = servletMapping.getServletName();
 
     try {
-      // TODO: review use of root factory.
-      resourceBase =
-          ResourceFactory.root().newResource(context.getResource("/" + appVersion.getPublicRoot()));
+      URL resourceBaseUrl = context.getResource("/" + appVersion.getPublicRoot());
+      resourceBase = (resourceBaseUrl == null) ? null : ResourceFactory.of(chandler).newResource(resourceBaseUrl);
     } catch (Exception ex) {
       throw new ServletException(ex);
     }

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/ResourceFileServlet.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/ResourceFileServlet.java
@@ -16,12 +16,13 @@
 
 package com.google.apphosting.runtime.jetty.ee8;
 
-import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.runtime.AppEngineConstants;
+import com.google.apphosting.runtime.AppVersion;
 import com.google.apphosting.utils.config.AppYaml;
 import com.google.common.base.Ascii;
 import com.google.common.flogger.GoogleLogger;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Objects;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
@@ -79,8 +80,8 @@ public class ResourceFileServlet extends HttpServlet {
     welcomeFiles = chandler.getWelcomeFiles();
 
     try {
-      // TODO: review use of root factory.
-      resourceBase = ResourceFactory.root().newResource(context.getResource("/" + appVersion.getPublicRoot()));
+      URL resourceBaseUrl = context.getResource("/" + appVersion.getPublicRoot());
+      resourceBase = (resourceBaseUrl == null) ? null : ResourceFactory.of(chandler).newResource(resourceBaseUrl);
     } catch (Exception ex) {
       throw new ServletException(ex);
     }


### PR DESCRIPTION
In `com.google.apphosting.runtime.jetty9.ResourceFileServlet` we were able to have a null `resourceBase` in the case that `context.getResource(URIUtil.SLASH + appVersion.getPublicRoot())` returned null.

However in Jetty 12 the `ResourceFactory#newResource` method will throw IAE if the given URL is null.

This PR restores the same behavior by allowing `ResourceFileServlet` to have a null `resourceBase` for the Jetty 12 based runtimes.