### PR TITLE
allow Jetty 9.4 jetty-servlets class names to work with Jetty 12

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
@@ -664,8 +664,9 @@ public class AppEngineWebAppContext extends WebAppContext {
         return null;
       }
 
-      if (holder.getClassName().startsWith(deprecated)) {
-        holder.setClassName(holder.getClassName().replace(deprecated, replacement));
+      String className = holder.getClassName();
+      if (className != null && className.startsWith(deprecated)) {
+        holder.setClassName(className.replace(deprecated, replacement));
       }
 
       return holder;
@@ -676,8 +677,9 @@ public class AppEngineWebAppContext extends WebAppContext {
         return null;
       }
 
-      if (holder.getClassName().startsWith(deprecated)) {
-        holder.setClassName(holder.getClassName().replace(deprecated, replacement));
+      String className = holder.getClassName();
+      if (className != null && className.startsWith(deprecated)) {
+        holder.setClassName(className.replace(deprecated, replacement));
       }
 
       return holder;

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
@@ -28,7 +28,7 @@ import com.google.apphosting.utils.servlet.ee10.JdbcMySqlConnectionCleanupFilter
 import com.google.apphosting.utils.servlet.ee10.SessionCleanupServlet;
 import com.google.apphosting.utils.servlet.ee10.SnapshotServlet;
 import com.google.apphosting.utils.servlet.ee10.WarmupServlet;
-import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableMap;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
 import jakarta.servlet.Servlet;
@@ -91,8 +91,9 @@ public class AppEngineWebAppContext extends WebAppContext {
   private final List<RequestListener> requestListeners = new CopyOnWriteArrayList<>();
   private final boolean ignoreContentLength;
 
-  private static final ImmutableSet<HolderTransformer> HOLDER_TRANSFORMERS = ImmutableSet.of(
-          new AppEngineWebAppContext.HolderTransformer("org.eclipse.jetty.servlets", "org.eclipse.jetty.ee10.servlets")
+  // Map of deprecated package names to their replacements.
+  private static final Map<String, String> DEPRECATED_PACKAGE_NAMES = ImmutableMap.of(
+          "org.eclipse.jetty.servlets", "org.eclipse.jetty.ee10.servlets"
   );
 
   @Override
@@ -416,12 +417,13 @@ public class AppEngineWebAppContext extends WebAppContext {
 
     TrimmedServlets(ServletHolder[] holders, ServletMapping[] mappings) {
       for (ServletHolder h : holders) {
-        for (HolderTransformer transformer : HOLDER_TRANSFORMERS) {
-          h = transformer.transform(h);
-        }
 
-        if (h == null) {
-          continue;
+        // Replace deprecated package names.
+        String className = h.getClassName();
+        if (className != null)
+        {
+          DEPRECATED_PACKAGE_NAMES.forEach((deprecated, replacement) ->
+                  h.setClassName(className.replace(deprecated, replacement)));
         }
 
         h.setAsyncSupported(APP_IS_ASYNC);
@@ -546,12 +548,13 @@ public class AppEngineWebAppContext extends WebAppContext {
 
     TrimmedFilters(FilterHolder[] holders, FilterMapping[] mappings) {
       for (FilterHolder h : holders) {
-        for (HolderTransformer transformer : HOLDER_TRANSFORMERS) {
-          h = transformer.transform(h);
-        }
 
-        if (h == null) {
-          continue;
+        // Replace deprecated package names.
+        String className = h.getClassName();
+        if (className != null)
+        {
+          DEPRECATED_PACKAGE_NAMES.forEach((deprecated, replacement) ->
+                  h.setClassName(className.replace(deprecated, replacement)));
         }
 
         h.setAsyncSupported(APP_IS_ASYNC);
@@ -646,34 +649,6 @@ public class AppEngineWebAppContext extends WebAppContext {
         }
       }
       return trimmed.toArray(new FilterMapping[0]);
-    }
-  }
-
-  private static class HolderTransformer
-  {
-    private final String deprecated;
-    private final String replacement;
-
-    public HolderTransformer(String deprecated, String replacement) {
-      this.deprecated = deprecated;
-      this.replacement = replacement;
-    }
-
-    public <T extends Holder<?>> T transform(T holder) {
-      if (holder == null) {
-        return null;
-      }
-
-      String className = holder.getClassName();
-      if (className != null && className.startsWith(deprecated)) {
-        if (replacement == null) {
-          return null;
-        }
-
-        holder.setClassName(className.replace(deprecated, replacement));
-      }
-
-      return holder;
     }
   }
 }

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
@@ -659,26 +659,17 @@ public class AppEngineWebAppContext extends WebAppContext {
       this.replacement = replacement;
     }
 
-    public ServletHolder transform(ServletHolder holder) {
-      if (replacement == null || holder == null) {
+    public <T extends Holder<?>> T transform(T holder) {
+      if (holder == null) {
         return null;
       }
 
       String className = holder.getClassName();
       if (className != null && className.startsWith(deprecated)) {
-        holder.setClassName(className.replace(deprecated, replacement));
-      }
+        if (replacement == null) {
+          return null;
+        }
 
-      return holder;
-    }
-
-    public FilterHolder transform(FilterHolder holder) {
-      if (replacement == null || holder == null) {
-        return null;
-      }
-
-      String className = holder.getClassName();
-      if (className != null && className.startsWith(deprecated)) {
         holder.setClassName(className.replace(deprecated, replacement));
       }
 

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
@@ -422,8 +422,11 @@ public class AppEngineWebAppContext extends WebAppContext {
         String className = h.getClassName();
         if (className != null)
         {
-          DEPRECATED_PACKAGE_NAMES.forEach((deprecated, replacement) ->
-                  h.setClassName(className.replace(deprecated, replacement)));
+          for (Map.Entry<String, String> entry : DEPRECATED_PACKAGE_NAMES.entrySet()) {
+            if (className.startsWith(entry.getKey())) {
+              h.setClassName(className.replace(entry.getKey(), entry.getValue()));
+            }
+          }
         }
 
         h.setAsyncSupported(APP_IS_ASYNC);
@@ -553,8 +556,11 @@ public class AppEngineWebAppContext extends WebAppContext {
         String className = h.getClassName();
         if (className != null)
         {
-          DEPRECATED_PACKAGE_NAMES.forEach((deprecated, replacement) ->
-                  h.setClassName(className.replace(deprecated, replacement)));
+          for (Map.Entry<String, String> entry : DEPRECATED_PACKAGE_NAMES.entrySet()) {
+            if (className.startsWith(entry.getKey())) {
+              h.setClassName(className.replace(entry.getKey(), entry.getValue()));
+            }
+          }
         }
 
         h.setAsyncSupported(APP_IS_ASYNC);

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -53,6 +53,7 @@ import org.eclipse.jetty.ee8.security.ConstraintMapping;
 import org.eclipse.jetty.ee8.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee8.servlet.FilterHolder;
 import org.eclipse.jetty.ee8.servlet.FilterMapping;
+import org.eclipse.jetty.ee8.servlet.Holder;
 import org.eclipse.jetty.ee8.servlet.ListenerHolder;
 import org.eclipse.jetty.ee8.servlet.ServletHandler;
 import org.eclipse.jetty.ee8.servlet.ServletHolder;
@@ -633,26 +634,17 @@ public class AppEngineWebAppContext extends WebAppContext {
       this.replacement = replacement;
     }
 
-    public ServletHolder transform(ServletHolder holder) {
-      if (replacement == null || holder == null) {
+    public <T extends Holder<?>> T transform(T holder) {
+      if (holder == null) {
         return null;
       }
 
       String className = holder.getClassName();
       if (className != null && className.startsWith(deprecated)) {
-        holder.setClassName(className.replace(deprecated, replacement));
-      }
+        if (replacement == null) {
+          return null;
+        }
 
-      return holder;
-    }
-
-    public FilterHolder transform(FilterHolder holder) {
-      if (replacement == null || holder == null) {
-        return null;
-      }
-
-      String className = holder.getClassName();
-      if (className != null && className.startsWith(deprecated)) {
         holder.setClassName(className.replace(deprecated, replacement));
       }
 

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -638,8 +638,9 @@ public class AppEngineWebAppContext extends WebAppContext {
         return null;
       }
 
-      if (holder.getClassName().startsWith(deprecated)) {
-        holder.setClassName(holder.getClassName().replace(deprecated, replacement));
+      String className = holder.getClassName();
+      if (className != null && className.startsWith(deprecated)) {
+        holder.setClassName(className.replace(deprecated, replacement));
       }
 
       return holder;
@@ -650,8 +651,9 @@ public class AppEngineWebAppContext extends WebAppContext {
         return null;
       }
 
-      if (holder.getClassName().startsWith(deprecated)) {
-        holder.setClassName(holder.getClassName().replace(deprecated, replacement));
+      String className = holder.getClassName();
+      if (className != null && className.startsWith(deprecated)) {
+        holder.setClassName(className.replace(deprecated, replacement));
       }
 
       return holder;

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -396,8 +396,11 @@ public class AppEngineWebAppContext extends WebAppContext {
         String className = h.getClassName();
         if (className != null)
         {
-          DEPRECATED_PACKAGE_NAMES.forEach((deprecated, replacement) ->
-                  h.setClassName(className.replace(deprecated, replacement)));
+          for (Map.Entry<String, String> entry : DEPRECATED_PACKAGE_NAMES.entrySet()) {
+            if (className.startsWith(entry.getKey())) {
+              h.setClassName(className.replace(entry.getKey(), entry.getValue()));
+            }
+          }
         }
 
         h.setAsyncSupported(APP_IS_ASYNC);
@@ -527,8 +530,11 @@ public class AppEngineWebAppContext extends WebAppContext {
         String className = h.getClassName();
         if (className != null)
         {
-          DEPRECATED_PACKAGE_NAMES.forEach((deprecated, replacement) ->
-                  h.setClassName(className.replace(deprecated, replacement)));
+          for (Map.Entry<String, String> entry : DEPRECATED_PACKAGE_NAMES.entrySet()) {
+            if (className.startsWith(entry.getKey())) {
+              h.setClassName(className.replace(entry.getKey(), entry.getValue()));
+            }
+          }
         }
 
         h.setAsyncSupported(APP_IS_ASYNC);


### PR DESCRIPTION
The package name of `jetty-servlets` classes has changed from Jetty 9.4 to Jetty 12.

This PR allows applications to use the old `jetty-servlets` class names, for example `org.eclipse.jetty.servlets.CrossOriginFilter` would be translated to `org.eclipse.jetty.ee8.servlets.CrossOriginFilter` for the EE8 environment.