### PR TITLE
fix JSPs from appengine-local-runtime-shared-jetty12

### DIFF
--- a/local_runtime_shared_jetty12/pom.xml
+++ b/local_runtime_shared_jetty12/pom.xml
@@ -45,19 +45,6 @@
       <artifactId>runtime-shared</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>apache-jsp</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-jsp</artifactId>
-    </dependency>
-    <dependency>
-       <groupId>org.eclipse.jetty.ee10</groupId>
-       <artifactId>jetty-ee10-apache-jsp</artifactId>
-       <version>${jetty12.version}</version>
-    </dependency>    
-    <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
@@ -89,8 +76,8 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-jspc-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-jspc-maven-plugin</artifactId>
         <executions>
           <execution>
             <id>jspc</id>


### PR DESCRIPTION
The EE8 JSPs in `appengine-local-runtime-shared-jetty12` were being compiled with an older version of org.mortbay.jasper:apache-jsp which was causing the following error 
> Caused by: javax.servlet.ServletException: java.lang.NoSuchMethodError: 'void org.apache.jasper.runtime.JspRuntimeLibrary.releaseTag(javax.servlet.jsp.tagext.Tag, org.apache.tomcat.InstanceManager, boolean)'


I have tested `/_ah/admin` which now successfully displays the page, however there seems to be other issues with its functionality which requires further investigation.