### PR TITLE
allow use of old package name for ResourceFileServlet

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
@@ -92,10 +92,7 @@ public class AppEngineWebAppContext extends WebAppContext {
   private final boolean ignoreContentLength;
 
   // Map of deprecated package names to their replacements.
-  private static final Map<String, String> DEPRECATED_PACKAGE_NAMES = ImmutableMap.of(
-          "org.eclipse.jetty.servlets", "org.eclipse.jetty.ee10.servlets",
-          "org.eclipse.jetty.servlet", "org.eclipse.jetty.ee10.servlet"
-  );
+  private static final Map<String, String> DEPRECATED_PACKAGE_NAMES = ImmutableMap.of();
 
   @Override
   public boolean checkAlias(String path, Resource resource) {

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -96,7 +96,7 @@ public class AppEngineWebAppContext extends WebAppContext {
   private static final Map<String, String> DEPRECATED_PACKAGE_NAMES = ImmutableMap.of(
           "org.eclipse.jetty.servlets", "org.eclipse.jetty.ee8.servlets",
           "org.eclipse.jetty.servlet", "org.eclipse.jetty.ee8.servlet",
-          "com.google.apphosting.runtime.jetty9.ResourceFileServlet", "com.google.apphosting.runtime.jetty.ee8.ResourceFileServlet"
+          "com.google.apphosting.runtime.jetty9", "com.google.apphosting.runtime.jetty.ee8"
   );
 
   @Override

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -96,7 +96,9 @@ public class AppEngineWebAppContext extends WebAppContext {
   private static final Map<String, String> DEPRECATED_PACKAGE_NAMES = ImmutableMap.of(
           "org.eclipse.jetty.servlets", "org.eclipse.jetty.ee8.servlets",
           "org.eclipse.jetty.servlet", "org.eclipse.jetty.ee8.servlet",
-          "com.google.apphosting.runtime.jetty9", "com.google.apphosting.runtime.jetty.ee8"
+          "com.google.apphosting.runtime.jetty9.NamedDefaultServlet", "com.google.apphosting.runtime.jetty.ee8.NamedDefaultServlet",
+          "com.google.apphosting.runtime.jetty9.NamedJspServlet", "com.google.apphosting.runtime.jetty.ee8.NamedJspServlet",
+          "com.google.apphosting.runtime.jetty9.ResourceFileServlet", "com.google.apphosting.runtime.jetty.ee8.ResourceFileServlet"
   );
 
   @Override

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -95,7 +95,8 @@ public class AppEngineWebAppContext extends WebAppContext {
   // Map of deprecated package names to their replacements.
   private static final Map<String, String> DEPRECATED_PACKAGE_NAMES = ImmutableMap.of(
           "org.eclipse.jetty.servlets", "org.eclipse.jetty.ee8.servlets",
-          "org.eclipse.jetty.servlet", "org.eclipse.jetty.ee8.servlet"
+          "org.eclipse.jetty.servlet", "org.eclipse.jetty.ee8.servlet",
+          "com.google.apphosting.runtime.jetty9.ResourceFileServlet", "com.google.apphosting.runtime.jetty.ee8.ResourceFileServlet"
   );
 
   @Override


### PR DESCRIPTION
Allow `com.google.apphosting.runtime.jetty9.ResourceFileServlet` to be used for apps on Java 21 runtime using EE8, even though package name has changed to `com.google.apphosting.runtime.jetty.ee8.ResourceFileServlet`.

Remove `DEPRECATED_PACKAGE_NAMES` values for EE10, as code changes and redeployment are required to upgrade to EE10.