### PR TITLE
Add flag to force Metadata Not Complete in EE8 runtime

### DIFF
--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -117,6 +117,9 @@ public class AppEngineWebAppContext extends WebAppContext {
     // If the application fails to start, we throw so the JVM can exit.
     setThrowUnavailableOnStartupException(true);
 
+    // This is a workaround to allow old quickstart-web.xml from Jetty 9.4 to be deployed.
+    setAttribute("org.eclipse.jetty.ee8.annotations.AnnotationIntrospector.ForceMetadataNotComplete", "true");
+
     // We do this here because unlike EE10 there is no easy way
     // to override createTempDirectory on the CoreContextHandler.
     createTempDirectory();


### PR DESCRIPTION
This flag is required to fix #358 

This only exists from Jetty `12.0.20+`