### PR TITLE
Allows non ancestor queries inside a transaction in remote api context

### DIFF
--- a/api/src/main/java/com/google/apphosting/utils/remoteapi/EE10RemoteApiServlet.java
+++ b/api/src/main/java/com/google/apphosting/utils/remoteapi/EE10RemoteApiServlet.java
@@ -261,10 +261,6 @@ public class EE10RemoteApiServlet extends HttpServlet {
     TransactionQueryResult.Builder result = TransactionQueryResult.newBuilder();
     Query.Builder query = Query.newBuilder();
     parseFromBytes(query, request.getRequest().toByteArray());
-    if (!query.hasAncestor()) {
-      throw new ApiProxy.ApplicationException(
-          BAD_REQUEST.getNumber(), "No ancestor in transactional query.");
-    }
     // Make __entity_group__ key
     OnestoreEntity.Reference.Builder egKey =
         result.getEntityGroupKeyBuilder().mergeFrom(query.getAncestor());

--- a/api/src/main/java/com/google/apphosting/utils/remoteapi/RemoteApiServlet.java
+++ b/api/src/main/java/com/google/apphosting/utils/remoteapi/RemoteApiServlet.java
@@ -261,10 +261,6 @@ public class RemoteApiServlet extends HttpServlet {
     TransactionQueryResult.Builder result = TransactionQueryResult.newBuilder();
     Query.Builder query = Query.newBuilder();
     parseFromBytes(query, request.getRequest().toByteArray());
-    if (!query.hasAncestor()) {
-      throw new ApiProxy.ApplicationException(
-          BAD_REQUEST.getNumber(), "No ancestor in transactional query.");
-    }
     // Make __entity_group__ key
     OnestoreEntity.Reference.Builder egKey =
         result.getEntityGroupKeyBuilder().mergeFrom(query.getAncestor());


### PR DESCRIPTION
In the pull request #366 I've left behind a change inside the remote api servlets and so, in remote api context, the non ancestor queries insieme a transaction fails.

In this pull request I've removed the check inside the two remote api servlets.
