### PR TITLE
Creating a new  version for releasing the SMTP Mail changes to Beta

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,6 +28,7 @@
   </properties>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-apis</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>API for Google App Engine standard environment</description>
   <dependencies>
     <dependency>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/api_dev/pom.xml
+++ b/api_dev/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-apis-dev</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>SDK for dev_appserver (local development)</description>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/api_dev/pom.xml
+++ b/api_dev/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/api_legacy/pom.xml
+++ b/api_legacy/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/api_legacy/pom.xml
+++ b/api_legacy/pom.xml
@@ -27,6 +27,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-api-legacy</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>
     Legacy appengine API's that have been removed from appengine-api-sdk-1.0
   </description>

--- a/appengine-api-1.0-sdk/pom.xml
+++ b/appengine-api-1.0-sdk/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-api-1.0-sdk</name>

--- a/appengine-api-1.0-sdk/pom.xml
+++ b/appengine-api-1.0-sdk/pom.xml
@@ -528,6 +528,39 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <notimestamp>true</notimestamp>
+          <show>public</show>
+          <failOnWarnings>false</failOnWarnings>
+          <doclint>none</doclint>
+          <sourcepath>${project.basedir}/../api/src/main/java</sourcepath>
+          <includeDependencySources>true</includeDependencySources>
+          <additionalDependencies>
+            <additionalDependency>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>1.0-rc2</version>
+            </additionalDependency>
+            <additionalDependency>
+              <groupId>com.google.auto</groupId>
+              <artifactId>auto-common</artifactId>
+              <version>1.2.1</version>
+            </additionalDependency>
+          </additionalDependencies>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-api-1.0-sdk/pom.xml
+++ b/appengine-api-1.0-sdk/pom.xml
@@ -24,6 +24,7 @@
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-api-1.0-sdk</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>API for Google App Engine standard environment with some of the dependencies shaded (repackaged)</description>
   <dependencies>
     <dependency> <!-- needed for remote_api for opencensus. -->

--- a/appengine-api-stubs/pom.xml
+++ b/appengine-api-stubs/pom.xml
@@ -378,6 +378,32 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <notimestamp>true</notimestamp>
+          <show>public</show>
+          <failOnWarnings>false</failOnWarnings>
+          <doclint>none</doclint>
+          <sourcepath>${project.basedir}/../api_dev/src/main/java</sourcepath>
+          <additionalDependencies>
+            <additionalDependency>
+              <groupId>com.google.auto.service</groupId>
+              <artifactId>auto-service</artifactId>
+              <version>1.0-rc2</version>
+            </additionalDependency>
+          </additionalDependencies>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/appengine-api-stubs/pom.xml
+++ b/appengine-api-stubs/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-api-stubs</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>
     SDK for dev_appserver (local development) with some of the dependencies shaded (repackaged)
   </description>

--- a/appengine-api-stubs/pom.xml
+++ b/appengine-api-stubs/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/appengine_init/pom.xml
+++ b/appengine_init/pom.xml
@@ -29,6 +29,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-init</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine initialization.</description>
 
     <dependencies>
  

--- a/appengine_init/pom.xml
+++ b/appengine_init/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/appengine_init/pom.xml
+++ b/appengine_init/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-init</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <dependencies>
  

--- a/appengine_jsr107/pom.xml
+++ b/appengine_jsr107/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/appengine_jsr107/pom.xml
+++ b/appengine_jsr107/pom.xml
@@ -21,6 +21,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: appengine-jsr107</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>App Engine JSR-107 (JCache) integration.</description>
 
     <parent>
         <groupId>com.google.appengine</groupId>

--- a/appengine_jsr107/pom.xml
+++ b/appengine_jsr107/pom.xml
@@ -20,6 +20,7 @@
     <artifactId>appengine-jsr107</artifactId>
     <packaging>jar</packaging>
     <name>AppEngine :: appengine-jsr107</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <parent>
         <groupId>com.google.appengine</groupId>

--- a/appengine_resources/pom.xml
+++ b/appengine_resources/pom.xml
@@ -26,6 +26,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-resources</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine resources.</description>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/appengine_resources/pom.xml
+++ b/appengine_resources/pom.xml
@@ -25,6 +25,7 @@
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-resources</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/appengine_resources/pom.xml
+++ b/appengine_resources/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-resources</name>

--- a/appengine_setup/apiserver_local/pom.xml
+++ b/appengine_setup/apiserver_local/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>appengine_setup</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/appengine_setup/pom.xml
+++ b/appengine_setup/pom.xml
@@ -33,6 +33,7 @@
   </modules>
   <packaging>pom</packaging>
   <name>AppEngine :: appengine_setup</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>DO NOT USE - Presently in Beta Mode. Library to help setup AppEngine features (bundled services, session management, etc).</description>
 
   <properties>

--- a/appengine_setup/pom.xml
+++ b/appengine_setup/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <modules>
     <module>apiserver_local</module>

--- a/appengine_setup/test/pom.xml
+++ b/appengine_setup/test/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>appengine_setup</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.appengine</groupId>

--- a/appengine_setup/test/src/test/java/com/google/appengine/setup/test/Jetty12TestAppTest.java
+++ b/appengine_setup/test/src/test/java/com/google/appengine/setup/test/Jetty12TestAppTest.java
@@ -26,6 +26,6 @@ public class Jetty12TestAppTest extends TestAppBase {
     @Override
     protected String relativePathForUserApplicationJar() {
     return "../testapps/jetty12_testapp/target/"
-        + "jetty12_testapp-2.0.39-SNAPSHOT-jar-with-dependencies.jar";
+        + "jetty12_testapp-2.0.39-beta-SNAPSHOT-jar-with-dependencies.jar";
     }
 }

--- a/appengine_setup/test/src/test/java/com/google/appengine/setup/test/SpringBootTestAppTest.java
+++ b/appengine_setup/test/src/test/java/com/google/appengine/setup/test/SpringBootTestAppTest.java
@@ -25,6 +25,6 @@ public class SpringBootTestAppTest extends TestAppBase{
 
     @Override
     protected String relativePathForUserApplicationJar() {
-    return "../testapps/springboot_testapp/target/" + "springboot_testapp-2.0.39-SNAPSHOT.jar";
+    return "../testapps/springboot_testapp/target/" + "springboot_testapp-2.0.39-beta-SNAPSHOT.jar";
     }
 }

--- a/appengine_setup/test/src/test/java/com/google/appengine/setup/test/util/TestUtil.java
+++ b/appengine_setup/test/src/test/java/com/google/appengine/setup/test/util/TestUtil.java
@@ -62,7 +62,7 @@ public class TestUtil {
     @SneakyThrows
     public static Process initializeHttpApiServer() {
     String apiServerRelativeJarPath =
-        "../apiserver_local/target/" + "apiserver_local-2.0.39-SNAPSHOT-jar-with-dependencies.jar";
+        "../apiserver_local/target/" + "apiserver_local-2.0.39-beta-SNAPSHOT-jar-with-dependencies.jar";
         File currentDirectory = new File("").getAbsoluteFile();
         File apiServerJar = new File(currentDirectory, apiServerRelativeJarPath);
         ImmutableList<String> processArgs = ImmutableList.<String>builder()

--- a/appengine_setup/testapps/jetty12_testapp/pom.xml
+++ b/appengine_setup/testapps/jetty12_testapp/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>testapps</artifactId>
     <groupId>com.google.appengine</groupId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.appengine.setup.testapps</groupId>
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.google.appengine.setup.testapps</groupId>
       <artifactId>testapps_common</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -106,7 +106,7 @@
           <projectId>srirammahavadi-dev</projectId>
           <version>GCLOUD_CONFIG</version>
           <automaticRestart>true</automaticRestart>
-          <artifact>${project.build.directory}/jetty11_testapp-2.0.39-SNAPSHOT-jar-with-dependencies.jar</artifact>
+          <artifact>${project.build.directory}/jetty11_testapp-2.0.39-beta-SNAPSHOT-jar-with-dependencies.jar</artifact>
         </configuration>
       </plugin>
 

--- a/appengine_setup/testapps/pom.xml
+++ b/appengine_setup/testapps/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>appengine_setup</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.appengine</groupId>

--- a/appengine_setup/testapps/springboot_testapp/pom.xml
+++ b/appengine_setup/testapps/springboot_testapp/pom.xml
@@ -27,6 +27,7 @@
 	<artifactId>springboot_testapp</artifactId>
 	<version>2.0.39-beta-SNAPSHOT</version>
 	<name>springboot_testapp</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>8</java.version>

--- a/appengine_setup/testapps/springboot_testapp/pom.xml
+++ b/appengine_setup/testapps/springboot_testapp/pom.xml
@@ -25,7 +25,7 @@
 	</parent>
 	<groupId>com.google.appengine.setup.testapps</groupId>
 	<artifactId>springboot_testapp</artifactId>
-	<version>2.0.39-SNAPSHOT</version>
+	<version>2.0.39-beta-SNAPSHOT</version>
 	<name>springboot_testapp</name>
 	<description>Demo project for Spring Boot</description>
 	<properties>
@@ -44,12 +44,12 @@
 		<dependency>
 			<groupId>com.google.appengine</groupId>
 			<artifactId>appengine-api-1.0-sdk</artifactId>
-			<version>2.0.39-SNAPSHOT</version>
+			<version>2.0.39-beta-SNAPSHOT</version>
 		</dependency>
 	 <dependency>
 	  <groupId>com.google.appengine.setup.testapps</groupId>
 	  <artifactId>testapps_common</artifactId>
-	  <version>2.0.39-SNAPSHOT</version>
+	  <version>2.0.39-beta-SNAPSHOT</version>
 	  <type>jar</type>
 	 </dependency>
 	</dependencies>

--- a/appengine_setup/testapps/testapps_common/pom.xml
+++ b/appengine_setup/testapps/testapps_common/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>testapps</artifactId>
     <groupId>com.google.appengine</groupId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.appengine.setup.testapps</groupId>

--- a/appengine_testing/pom.xml
+++ b/appengine_testing/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-testing</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>Testing support for Google App Engine standard environment application code</description>
 
 

--- a/appengine_testing/pom.xml
+++ b/appengine_testing/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/appengine_testing_tests/pom.xml
+++ b/appengine_testing_tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/appengine_testing_tests/pom.xml
+++ b/appengine_testing_tests/pom.xml
@@ -28,6 +28,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: appengine-testing-tests</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
     <description>Tests for Testing support for Google App Engine standard environment application code</description>
 
 

--- a/applications/guestbook/pom.xml
+++ b/applications/guestbook/pom.xml
@@ -30,6 +30,7 @@
     <artifactId>guestbook</artifactId>
     <name>AppEngine :: guestbook</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A guestbook sample application.</description>
 
     <prerequisites>
         <maven>3.6.0</maven>

--- a/applications/guestbook/pom.xml
+++ b/applications/guestbook/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>applications</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>guestbook</artifactId>
@@ -36,7 +36,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <appengine.target.version>2.0.39-SNAPSHOT</appengine.target.version>
+        <appengine.target.version>2.0.39-beta-SNAPSHOT</appengine.target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/applications/guestbook/pom.xml
+++ b/applications/guestbook/pom.xml
@@ -29,6 +29,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>guestbook</artifactId>
     <name>AppEngine :: guestbook</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <prerequisites>
         <maven>3.6.0</maven>

--- a/applications/guestbook_jakarta/pom.xml
+++ b/applications/guestbook_jakarta/pom.xml
@@ -29,6 +29,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>guestbook_jakarta</artifactId>
     <name>AppEngine :: guestbook_jakarta</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <prerequisites>
         <maven>3.6.0</maven>

--- a/applications/guestbook_jakarta/pom.xml
+++ b/applications/guestbook_jakarta/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>applications</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>guestbook_jakarta</artifactId>
@@ -36,7 +36,7 @@
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
-        <appengine.target.version>2.0.39-SNAPSHOT</appengine.target.version>
+        <appengine.target.version>2.0.39-beta-SNAPSHOT</appengine.target.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/applications/guestbook_jakarta/pom.xml
+++ b/applications/guestbook_jakarta/pom.xml
@@ -30,6 +30,7 @@
     <artifactId>guestbook_jakarta</artifactId>
     <name>AppEngine :: guestbook_jakarta</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A guestbook sample application (Jakarta).</description>
 
     <prerequisites>
         <maven>3.6.0</maven>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -19,6 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>applications</artifactId>
   <name>AppEngine :: application projects</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -20,6 +20,7 @@
   <artifactId>applications</artifactId>
   <name>AppEngine :: application projects</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Parent POM for sample applications.</description>
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>

--- a/applications/pom.xml
+++ b/applications/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
   <properties>

--- a/applications/proberapp/pom.xml
+++ b/applications/proberapp/pom.xml
@@ -24,6 +24,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>proberapp</artifactId>
     <name>AppEngine :: proberapp</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>applications</artifactId>

--- a/applications/proberapp/pom.xml
+++ b/applications/proberapp/pom.xml
@@ -25,6 +25,7 @@
     <artifactId>proberapp</artifactId>
     <name>AppEngine :: proberapp</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A prober application.</description>
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>applications</artifactId>

--- a/applications/proberapp/pom.xml
+++ b/applications/proberapp/pom.xml
@@ -27,7 +27,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>applications</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
     <properties>

--- a/applications/springboot/pom.xml
+++ b/applications/springboot/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: springboot</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
     <description>Demo project for Spring Boot</description>
 
     <properties>

--- a/applications/springboot/pom.xml
+++ b/applications/springboot/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>applications</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/devappservertests/pom.xml
+++ b/e2etests/devappservertests/pom.xml
@@ -28,6 +28,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: e2e devappserver tests</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Tests for the development app server.</description>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/e2etests/devappservertests/pom.xml
+++ b/e2etests/devappservertests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>e2etests</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/e2etests/devappservertests/pom.xml
+++ b/e2etests/devappservertests/pom.xml
@@ -27,6 +27,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: e2e devappserver tests</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/e2etests/pom.xml
+++ b/e2etests/pom.xml
@@ -26,6 +26,7 @@
     <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <name>AppEngine :: e2e tests</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <packaging>pom</packaging>
 
   <modules>

--- a/e2etests/pom.xml
+++ b/e2etests/pom.xml
@@ -27,6 +27,7 @@
   </parent>
   <name>AppEngine :: e2e tests</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>End-to-end tests.</description>
   <packaging>pom</packaging>
 
   <modules>

--- a/e2etests/pom.xml
+++ b/e2etests/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <name>AppEngine :: e2e tests</name>
   <packaging>pom</packaging>

--- a/e2etests/stagingtests/pom.xml
+++ b/e2etests/stagingtests/pom.xml
@@ -27,6 +27,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: e2e staging tests</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/e2etests/stagingtests/pom.xml
+++ b/e2etests/stagingtests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>e2etests</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/e2etests/stagingtests/pom.xml
+++ b/e2etests/stagingtests/pom.xml
@@ -28,6 +28,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: e2e staging tests</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Tests for staging.</description>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/e2etests/testlocalapps/allinone/pom.xml
+++ b/e2etests/testlocalapps/allinone/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: allinone test application</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>An all-in-one sample application.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/allinone/pom.xml
+++ b/e2etests/testlocalapps/allinone/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/allinone/pom.xml
+++ b/e2etests/testlocalapps/allinone/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: allinone test application</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/allinone_jakarta/pom.xml
+++ b/e2etests/testlocalapps/allinone_jakarta/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: allinone test application Jarkata</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/allinone_jakarta/pom.xml
+++ b/e2etests/testlocalapps/allinone_jakarta/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/allinone_jakarta/pom.xml
+++ b/e2etests/testlocalapps/allinone_jakarta/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: allinone test application Jarkata</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>An all-in-one sample application (Jakarta).</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/badcron/pom.xml
+++ b/e2etests/testlocalapps/badcron/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: badcron</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/badcron/pom.xml
+++ b/e2etests/testlocalapps/badcron/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: badcron</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a bad cron job.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/badcron/pom.xml
+++ b/e2etests/testlocalapps/badcron/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/bundle_standard/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard/pom.xml
@@ -29,6 +29,7 @@
   <packaging>war</packaging>
 
   <name>AppEngine :: bundle_standard</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/bundle_standard/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>testlocalapps</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/bundle_standard/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard/pom.xml
@@ -30,6 +30,7 @@
 
   <name>AppEngine :: bundle_standard</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>A sample application that bundles the standard App Engine API.</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/bundle_standard_with_container_initializer/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_container_initializer/pom.xml
@@ -31,6 +31,7 @@
 
   <name>AppEngine :: bundle_standard_with_container_initializer</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>A sample application that bundles the standard App Engine API with a container initializer.</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/bundle_standard_with_container_initializer/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_container_initializer/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>testlocalapps</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/bundle_standard_with_container_initializer/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_container_initializer/pom.xml
@@ -30,6 +30,7 @@
   <packaging>war</packaging>
 
   <name>AppEngine :: bundle_standard_with_container_initializer</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/bundle_standard_with_no_jsp/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_no_jsp/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>testlocalapps</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/bundle_standard_with_no_jsp/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_no_jsp/pom.xml
@@ -29,6 +29,7 @@
   <packaging>war</packaging>
 
   <name>AppEngine :: bundle_standard_with_no_jsp</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/bundle_standard_with_no_jsp/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_no_jsp/pom.xml
@@ -30,6 +30,7 @@
 
   <name>AppEngine :: bundle_standard_with_no_jsp</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>A sample application that bundles the standard App Engine API but contains no JSPs.</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/bundle_standard_with_weblistener_memcache/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_weblistener_memcache/pom.xml
@@ -30,6 +30,7 @@
 
   <name>AppEngine :: bundle_standard_with_weblistener_memcache</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>A sample application that bundles the standard App Engine API with a web listener for memcache.</description>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/bundle_standard_with_weblistener_memcache/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_weblistener_memcache/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>testlocalapps</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/bundle_standard_with_weblistener_memcache/pom.xml
+++ b/e2etests/testlocalapps/bundle_standard_with_weblistener_memcache/pom.xml
@@ -29,6 +29,7 @@
   <packaging>war</packaging>
 
   <name>AppEngine :: bundle_standard_with_weblistener_memcache</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-bad-job-age-limit/pom.xml
+++ b/e2etests/testlocalapps/cron-bad-job-age-limit/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: cron-bad-job-age-limit</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-bad-job-age-limit/pom.xml
+++ b/e2etests/testlocalapps/cron-bad-job-age-limit/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: cron-bad-job-age-limit</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a cron job with a bad age limit.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-bad-job-age-limit/pom.xml
+++ b/e2etests/testlocalapps/cron-bad-job-age-limit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/cron-good-retry-parameters/pom.xml
+++ b/e2etests/testlocalapps/cron-good-retry-parameters/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/cron-good-retry-parameters/pom.xml
+++ b/e2etests/testlocalapps/cron-good-retry-parameters/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: cron-good-retry-parameters</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a cron job with good retry parameters.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-good-retry-parameters/pom.xml
+++ b/e2etests/testlocalapps/cron-good-retry-parameters/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: cron-good-retry-parameters</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-negative-max-backoff/pom.xml
+++ b/e2etests/testlocalapps/cron-negative-max-backoff/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: cron-negative-max-backoff</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-negative-max-backoff/pom.xml
+++ b/e2etests/testlocalapps/cron-negative-max-backoff/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/cron-negative-max-backoff/pom.xml
+++ b/e2etests/testlocalapps/cron-negative-max-backoff/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: cron-negative-max-backoff</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a cron job with a negative max backoff.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-negative-retry-limit/pom.xml
+++ b/e2etests/testlocalapps/cron-negative-retry-limit/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: cron-negative-retry-limit</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-negative-retry-limit/pom.xml
+++ b/e2etests/testlocalapps/cron-negative-retry-limit/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: cron-negative-retry-limit</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a cron job with a negative retry limit.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-negative-retry-limit/pom.xml
+++ b/e2etests/testlocalapps/cron-negative-retry-limit/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/cron-two-max-doublings/pom.xml
+++ b/e2etests/testlocalapps/cron-two-max-doublings/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/cron-two-max-doublings/pom.xml
+++ b/e2etests/testlocalapps/cron-two-max-doublings/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: cron-two-max-doublings</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a cron job with two max doublings.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/cron-two-max-doublings/pom.xml
+++ b/e2etests/testlocalapps/cron-two-max-doublings/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: cron-two-max-doublings</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/http-headers/pom.xml
+++ b/e2etests/testlocalapps/http-headers/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: http-headers</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application for testing HTTP headers.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/http-headers/pom.xml
+++ b/e2etests/testlocalapps/http-headers/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: http-headers</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/http-headers/pom.xml
+++ b/e2etests/testlocalapps/http-headers/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/java8-jar/pom.xml
+++ b/e2etests/testlocalapps/java8-jar/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: java8-jar</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample Java 8 application in a JAR.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/java8-jar/pom.xml
+++ b/e2etests/testlocalapps/java8-jar/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/java8-jar/pom.xml
+++ b/e2etests/testlocalapps/java8-jar/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: java8-jar</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/java8-no-webxml/pom.xml
+++ b/e2etests/testlocalapps/java8-no-webxml/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: java8-no-webxml</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/java8-no-webxml/pom.xml
+++ b/e2etests/testlocalapps/java8-no-webxml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/java8-no-webxml/pom.xml
+++ b/e2etests/testlocalapps/java8-no-webxml/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: java8-no-webxml</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample Java 8 application with no web.xml.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/pom.xml
+++ b/e2etests/testlocalapps/pom.xml
@@ -19,6 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>testlocalapps</artifactId>
   <name>AppEngine :: Test local applications</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>e2etests</artifactId>

--- a/e2etests/testlocalapps/pom.xml
+++ b/e2etests/testlocalapps/pom.xml
@@ -20,6 +20,7 @@
   <artifactId>testlocalapps</artifactId>
   <name>AppEngine :: Test local applications</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Test applications for local development.</description>
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>e2etests</artifactId>

--- a/e2etests/testlocalapps/pom.xml
+++ b/e2etests/testlocalapps/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>e2etests</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
   <properties>

--- a/e2etests/testlocalapps/sample-badaeweb/pom.xml
+++ b/e2etests/testlocalapps/sample-badaeweb/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-badaeweb</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a bad appengine-web.xml.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badaeweb/pom.xml
+++ b/e2etests/testlocalapps/sample-badaeweb/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-badaeweb</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badaeweb/pom.xml
+++ b/e2etests/testlocalapps/sample-badaeweb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-baddispatch-yaml/pom.xml
+++ b/e2etests/testlocalapps/sample-baddispatch-yaml/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-baddispatch-yaml</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a bad dispatch.yaml.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-baddispatch-yaml/pom.xml
+++ b/e2etests/testlocalapps/sample-baddispatch-yaml/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-baddispatch-yaml</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-baddispatch-yaml/pom.xml
+++ b/e2etests/testlocalapps/sample-baddispatch-yaml/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-baddispatch/pom.xml
+++ b/e2etests/testlocalapps/sample-baddispatch/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-baddispatch</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-baddispatch/pom.xml
+++ b/e2etests/testlocalapps/sample-baddispatch/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-baddispatch</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a bad dispatch file.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-baddispatch/pom.xml
+++ b/e2etests/testlocalapps/sample-baddispatch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-badentrypoint/pom.xml
+++ b/e2etests/testlocalapps/sample-badentrypoint/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-badentrypoint</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a bad entrypoint.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badentrypoint/pom.xml
+++ b/e2etests/testlocalapps/sample-badentrypoint/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-badentrypoint</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badentrypoint/pom.xml
+++ b/e2etests/testlocalapps/sample-badentrypoint/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-badindexes/pom.xml
+++ b/e2etests/testlocalapps/sample-badindexes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-badindexes/pom.xml
+++ b/e2etests/testlocalapps/sample-badindexes/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-badindexes</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badindexes/pom.xml
+++ b/e2etests/testlocalapps/sample-badindexes/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-badindexes</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with bad indexes.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badruntimechannel/pom.xml
+++ b/e2etests/testlocalapps/sample-badruntimechannel/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-badruntimechannel</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a bad runtime channel.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badruntimechannel/pom.xml
+++ b/e2etests/testlocalapps/sample-badruntimechannel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-badruntimechannel/pom.xml
+++ b/e2etests/testlocalapps/sample-badruntimechannel/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-badruntimechannel</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badweb/pom.xml
+++ b/e2etests/testlocalapps/sample-badweb/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-badweb</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badweb/pom.xml
+++ b/e2etests/testlocalapps/sample-badweb/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-badweb</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a bad web.xml.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-badweb/pom.xml
+++ b/e2etests/testlocalapps/sample-badweb/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-default-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-default-auto-ids/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-default-auto-ids</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-default-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-default-auto-ids/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-default-auto-ids</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with default auto-generated IDs.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-default-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-default-auto-ids/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-error-in-tag-file/pom.xml
+++ b/e2etests/testlocalapps/sample-error-in-tag-file/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-error-in-tag-file</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-error-in-tag-file/pom.xml
+++ b/e2etests/testlocalapps/sample-error-in-tag-file/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-error-in-tag-file/pom.xml
+++ b/e2etests/testlocalapps/sample-error-in-tag-file/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-error-in-tag-file</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with an error in a tag file.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-java11/pom.xml
+++ b/e2etests/testlocalapps/sample-java11/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-java11</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-java11/pom.xml
+++ b/e2etests/testlocalapps/sample-java11/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-java11</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample Java 11 application.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-java11/pom.xml
+++ b/e2etests/testlocalapps/sample-java11/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-java17/pom.xml
+++ b/e2etests/testlocalapps/sample-java17/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-java17</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample Java 17 application.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-java17/pom.xml
+++ b/e2etests/testlocalapps/sample-java17/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-java17/pom.xml
+++ b/e2etests/testlocalapps/sample-java17/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-java17</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-jsptaglibrary/pom.xml
+++ b/e2etests/testlocalapps/sample-jsptaglibrary/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-jsptaglibrary/pom.xml
+++ b/e2etests/testlocalapps/sample-jsptaglibrary/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-jsptaglibrary</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a JSP tag library.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-jsptaglibrary/pom.xml
+++ b/e2etests/testlocalapps/sample-jsptaglibrary/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-jsptaglibrary</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-jspx/pom.xml
+++ b/e2etests/testlocalapps/sample-jspx/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-jspx</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-jspx/pom.xml
+++ b/e2etests/testlocalapps/sample-jspx/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-jspx/pom.xml
+++ b/e2etests/testlocalapps/sample-jspx/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-jspx</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with JSPX files.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-legacy-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-legacy-auto-ids/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-legacy-auto-ids</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-legacy-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-legacy-auto-ids/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-legacy-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-legacy-auto-ids/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-legacy-auto-ids</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with legacy auto-generated IDs.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-missingappid/pom.xml
+++ b/e2etests/testlocalapps/sample-missingappid/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-missingappid</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-missingappid/pom.xml
+++ b/e2etests/testlocalapps/sample-missingappid/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-missingappid/pom.xml
+++ b/e2etests/testlocalapps/sample-missingappid/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-missingappid</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a missing App Engine application ID.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-nojsps/pom.xml
+++ b/e2etests/testlocalapps/sample-nojsps/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-nojsps</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-nojsps/pom.xml
+++ b/e2etests/testlocalapps/sample-nojsps/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-nojsps/pom.xml
+++ b/e2etests/testlocalapps/sample-nojsps/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-nojsps</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with no JSPs.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-unspecified-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-unspecified-auto-ids/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-unspecified-auto-ids</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-unspecified-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-unspecified-auto-ids/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-unspecified-auto-ids</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with unspecified auto-generated IDs.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-unspecified-auto-ids/pom.xml
+++ b/e2etests/testlocalapps/sample-unspecified-auto-ids/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sample-with-classes/pom.xml
+++ b/e2etests/testlocalapps/sample-with-classes/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sample-with-classes</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-with-classes/pom.xml
+++ b/e2etests/testlocalapps/sample-with-classes/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sample-with-classes</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with classes.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sample-with-classes/pom.xml
+++ b/e2etests/testlocalapps/sample-with-classes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sampleapp-automatic-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-automatic-module/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sampleapp-automatic-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-automatic-module/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sampleapp-automatic-module</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with an automatic module.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-automatic-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-automatic-module/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sampleapp-automatic-module</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-backends/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-backends/pom.xml
@@ -28,6 +28,7 @@
     </parent>
     <packaging>war</packaging>
     <name>AppEngine :: sampleapp-backends</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-backends/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-backends/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
     <name>AppEngine :: sampleapp-backends</name>

--- a/e2etests/testlocalapps/sampleapp-backends/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-backends/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
     <name>AppEngine :: sampleapp-backends</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with backends.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-basic-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-basic-module/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sampleapp-basic-module</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a basic module.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-basic-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-basic-module/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sampleapp-basic-module</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-basic-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-basic-module/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sampleapp-manual-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-manual-module/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sampleapp-manual-module</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-manual-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-manual-module/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sampleapp-manual-module</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application with a manual module.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-manual-module/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-manual-module/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sampleapp-runtime/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-runtime/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: sampleapp-runtime</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application runtime.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp-runtime/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-runtime/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/sampleapp-runtime/pom.xml
+++ b/e2etests/testlocalapps/sampleapp-runtime/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: sampleapp-runtime</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp/pom.xml
+++ b/e2etests/testlocalapps/sampleapp/pom.xml
@@ -28,6 +28,7 @@
       <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <name>AppEngine :: sampleapp</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/sampleapp/pom.xml
+++ b/e2etests/testlocalapps/sampleapp/pom.xml
@@ -25,7 +25,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <name>AppEngine :: sampleapp</name>
 

--- a/e2etests/testlocalapps/sampleapp/pom.xml
+++ b/e2etests/testlocalapps/sampleapp/pom.xml
@@ -29,6 +29,7 @@
     </parent>
     <name>AppEngine :: sampleapp</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/stage-sampleapp/pom.xml
+++ b/e2etests/testlocalapps/stage-sampleapp/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: stage-sampleapp</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/stage-sampleapp/pom.xml
+++ b/e2etests/testlocalapps/stage-sampleapp/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/stage-sampleapp/pom.xml
+++ b/e2etests/testlocalapps/stage-sampleapp/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: stage-sampleapp</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application for staging.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/stage-with-staging-options/pom.xml
+++ b/e2etests/testlocalapps/stage-with-staging-options/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
 
     <name>AppEngine :: stage-with-staging-options</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/stage-with-staging-options/pom.xml
+++ b/e2etests/testlocalapps/stage-with-staging-options/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
 

--- a/e2etests/testlocalapps/stage-with-staging-options/pom.xml
+++ b/e2etests/testlocalapps/stage-with-staging-options/pom.xml
@@ -30,6 +30,7 @@
 
     <name>AppEngine :: stage-with-staging-options</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application for staging with staging options.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/xmlorder/pom.xml
+++ b/e2etests/testlocalapps/xmlorder/pom.xml
@@ -28,6 +28,7 @@
     </parent>
     <packaging>war</packaging>
     <name>AppEngine :: xmlorder</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/e2etests/testlocalapps/xmlorder/pom.xml
+++ b/e2etests/testlocalapps/xmlorder/pom.xml
@@ -24,7 +24,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>testlocalapps</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <packaging>war</packaging>
     <name>AppEngine :: xmlorder</name>

--- a/e2etests/testlocalapps/xmlorder/pom.xml
+++ b/e2etests/testlocalapps/xmlorder/pom.xml
@@ -29,6 +29,7 @@
     <packaging>war</packaging>
     <name>AppEngine :: xmlorder</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A sample application to test XML order.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/external/geronimo_javamail/pom.xml
+++ b/external/geronimo_javamail/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/external/geronimo_javamail/pom.xml
+++ b/external/geronimo_javamail/pom.xml
@@ -29,6 +29,7 @@
     <artifactId>geronimo-javamail_1.4_spec</artifactId>
     <packaging>jar</packaging>
     <name>AppEngine :: JavaMail 1.4</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
     <version>1.4.4-${project.parent.version}</version>
 
     <description>Javamail 1.4 Specification with AppEngine updates.</description>

--- a/google3/third_party/java_src/appengine_standard/api_compatibility_tests/pom.xml
+++ b/google3/third_party/java_src/appengine_standard/api_compatibility_tests/pom.xml
@@ -27,6 +27,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-compatibility-tests</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>
     Compatibility tests for the Appengine APIs.
   </description>

--- a/google3/third_party/java_src/appengine_standard/api_compatibility_tests/pom.xml
+++ b/google3/third_party/java_src/appengine_standard/api_compatibility_tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/jetty12_assembly/pom.xml
+++ b/jetty12_assembly/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jetty12-assembly</artifactId>

--- a/jetty12_assembly/pom.xml
+++ b/jetty12_assembly/pom.xml
@@ -25,6 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>jetty12-assembly</artifactId>
     <name>AppEngine :: Jetty12 Assembly for the SDK</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
     <packaging>pom</packaging>
 
     <properties>

--- a/jetty12_assembly/pom.xml
+++ b/jetty12_assembly/pom.xml
@@ -26,6 +26,7 @@
     <artifactId>jetty12-assembly</artifactId>
     <name>AppEngine :: Jetty12 Assembly for the SDK</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>Assembly for Jetty 12.</description>
     <packaging>pom</packaging>
 
     <properties>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -19,6 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>lib-parent</artifactId>
   <name>AppEngine :: library projects</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>pom</packaging>
 

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -20,6 +20,7 @@
   <artifactId>lib-parent</artifactId>
   <name>AppEngine :: library projects</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Parent POM for libraries.</description>
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>

--- a/lib/tools_api/pom.xml
+++ b/lib/tools_api/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>lib-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/lib/tools_api/pom.xml
+++ b/lib/tools_api/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-tools-sdk (aka appengine-tools-api)</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <dependencies>
     <dependency>

--- a/lib/xml_validator/pom.xml
+++ b/lib/xml_validator/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>lib-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: libxmlvalidator</name>

--- a/lib/xml_validator/pom.xml
+++ b/lib/xml_validator/pom.xml
@@ -26,6 +26,7 @@
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: libxmlvalidator</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/lib/xml_validator/pom.xml
+++ b/lib/xml_validator/pom.xml
@@ -27,6 +27,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: libxmlvalidator</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>XML validator library.</description>
   <dependencies>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/lib/xml_validator_test/pom.xml
+++ b/lib/xml_validator_test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>lib-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: libxmlvalidator_test</name>

--- a/lib/xml_validator_test/pom.xml
+++ b/lib/xml_validator_test/pom.xml
@@ -27,6 +27,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: libxmlvalidator_test</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Tests for the XML validator library.</description>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/lib/xml_validator_test/pom.xml
+++ b/lib/xml_validator_test/pom.xml
@@ -26,6 +26,7 @@
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: libxmlvalidator_test</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/local_runtime_shared_jetty12/pom.xml
+++ b/local_runtime_shared_jetty12/pom.xml
@@ -26,6 +26,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime-shared Jetty12</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine local runtime shared components for Jetty 12.</description>
   <dependencies>
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/local_runtime_shared_jetty12/pom.xml
+++ b/local_runtime_shared_jetty12/pom.xml
@@ -25,6 +25,7 @@
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime-shared Jetty12</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <dependencies>
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/local_runtime_shared_jetty12/pom.xml
+++ b/local_runtime_shared_jetty12/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime-shared Jetty12</name>

--- a/local_runtime_shared_jetty9/pom.xml
+++ b/local_runtime_shared_jetty9/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime-shared Jetty9</name>

--- a/local_runtime_shared_jetty9/pom.xml
+++ b/local_runtime_shared_jetty9/pom.xml
@@ -25,6 +25,7 @@
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime-shared Jetty9</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <dependencies>
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/local_runtime_shared_jetty9/pom.xml
+++ b/local_runtime_shared_jetty9/pom.xml
@@ -26,6 +26,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime-shared Jetty9</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine local runtime shared components for Jetty 9.</description>
   <dependencies>
     <dependency>
       <groupId>com.google.appengine</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   <version>2.0.39-beta-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>AppEngine :: Parent project</name>
+  <description>Parent POM for the App Engine Java standard environment.</description>
   <modules>
     <module>external/geronimo_javamail</module>
     <module>protobuf</module>

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
                       <version>0.8.0</version>
                       <extensions>true</extensions>
                       <configuration>
-                          <publishingServerId>central</publishingServerId>
+                          <publishingServerId>${distributionManagement.snapshot.id}</publishingServerId>
                       </configuration>
                   </plugin>
               </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -185,6 +185,7 @@
                       <extensions>true</extensions>
                       <configuration>
                           <publishingServerId>${distributionManagement.snapshot.id}</publishingServerId>
+                          <autoPublish>true</autoPublish>
                       </configuration>
                   </plugin>
               </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -179,15 +179,13 @@
                       </executions>
                   </plugin>
                   <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.7.0</version>
-                    <extensions>true</extensions>
-                    <configuration>
-                      <serverId>${distributionManagement.snapshot.id}</serverId>
-                      <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                      <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                    </configuration>
+                      <groupId>org.sonatype.central</groupId>
+                      <artifactId>central-publishing-maven-plugin</artifactId>
+                      <version>0.8.0</version>
+                      <extensions>true</extensions>
+                      <configuration>
+                          <publishingServerId>central</publishingServerId>
+                      </configuration>
                   </plugin>
               </plugins>
           </build>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   <version>2.0.39-beta-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>AppEngine :: Parent project</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>Parent POM for the App Engine Java standard environment.</description>
   <modules>
     <module>external/geronimo_javamail</module>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.appengine</groupId>
   <artifactId>parent</artifactId>
-  <version>2.0.39-SNAPSHOT</version>
+  <version>2.0.39-beta-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>AppEngine :: Parent project</name>
   <modules>

--- a/protobuf/pom.xml
+++ b/protobuf/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: protos</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <dependencies>
     <dependency>

--- a/protobuf/pom.xml
+++ b/protobuf/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/protobuf/pom.xml
+++ b/protobuf/pom.xml
@@ -29,6 +29,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: protos</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Protocol buffers.</description>
 
   <dependencies>
     <dependency>

--- a/quickstartgenerator/pom.xml
+++ b/quickstartgenerator/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: quickstartgenerator Jetty9</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/quickstartgenerator/pom.xml
+++ b/quickstartgenerator/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/quickstartgenerator/pom.xml
+++ b/quickstartgenerator/pom.xml
@@ -29,6 +29,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: quickstartgenerator Jetty9</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Quickstart generator.</description>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/quickstartgenerator_jetty12/pom.xml
+++ b/quickstartgenerator_jetty12/pom.xml
@@ -29,6 +29,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: quickstartgenerator Jetty12</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Quickstart generator for Jetty 12.</description>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty.ee8</groupId>

--- a/quickstartgenerator_jetty12/pom.xml
+++ b/quickstartgenerator_jetty12/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: quickstartgenerator Jetty12</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty.ee8</groupId>

--- a/quickstartgenerator_jetty12/pom.xml
+++ b/quickstartgenerator_jetty12/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/quickstartgenerator_jetty12_ee10/pom.xml
+++ b/quickstartgenerator_jetty12_ee10/pom.xml
@@ -29,6 +29,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: quickstartgenerator Jetty12 EE10</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Quickstart generator for Jetty 12 and EE10.</description>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>

--- a/quickstartgenerator_jetty12_ee10/pom.xml
+++ b/quickstartgenerator_jetty12_ee10/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: quickstartgenerator Jetty12 EE10</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty.ee10</groupId>

--- a/quickstartgenerator_jetty12_ee10/pom.xml
+++ b/quickstartgenerator_jetty12_ee10/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/remoteapi/pom.xml
+++ b/remoteapi/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-remote-api</name>

--- a/remoteapi/pom.xml
+++ b/remoteapi/pom.xml
@@ -25,6 +25,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-remote-api</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine remote API.</description>
   <dependencies>
      <dependency>
        <groupId>com.google.api-client</groupId>

--- a/remoteapi/pom.xml
+++ b/remoteapi/pom.xml
@@ -24,6 +24,7 @@
   </parent>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-remote-api</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <dependencies>
      <dependency>
        <groupId>com.google.api-client</groupId>

--- a/runtime/annotationscanningwebapp/pom.xml
+++ b/runtime/annotationscanningwebapp/pom.xml
@@ -28,6 +28,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>annotationscanningwebapp</artifactId>
     <name>AppEngine :: annotationscanningwebapp</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/annotationscanningwebapp/pom.xml
+++ b/runtime/annotationscanningwebapp/pom.xml
@@ -29,6 +29,7 @@
     <artifactId>annotationscanningwebapp</artifactId>
     <name>AppEngine :: annotationscanningwebapp</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A web application for annotation scanning.</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/annotationscanningwebapp/pom.xml
+++ b/runtime/annotationscanningwebapp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>runtime-parent</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>annotationscanningwebapp</artifactId>

--- a/runtime/annotationscanningwebappjakarta/pom.xml
+++ b/runtime/annotationscanningwebappjakarta/pom.xml
@@ -28,6 +28,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>annotationscanningwebappjakarta</artifactId>
     <name>AppEngine :: annotationscanningwebapp jakarta</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/annotationscanningwebappjakarta/pom.xml
+++ b/runtime/annotationscanningwebappjakarta/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>runtime-parent</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>annotationscanningwebappjakarta</artifactId>

--- a/runtime/annotationscanningwebappjakarta/pom.xml
+++ b/runtime/annotationscanningwebappjakarta/pom.xml
@@ -29,6 +29,7 @@
     <artifactId>annotationscanningwebappjakarta</artifactId>
     <name>AppEngine :: annotationscanningwebapp jakarta</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A web application for annotation scanning (Jakarta).</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/deployment/pom.xml
+++ b/runtime/deployment/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>runtime-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>pom</packaging>

--- a/runtime/deployment/pom.xml
+++ b/runtime/deployment/pom.xml
@@ -27,6 +27,7 @@
 
   <packaging>pom</packaging>
   <name>AppEngine :: runtime-deployment</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>Produces an output directory in the format expected by the Java runtime.</description>
 
   <dependencies>

--- a/runtime/failinitfilterwebapp/pom.xml
+++ b/runtime/failinitfilterwebapp/pom.xml
@@ -28,6 +28,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>failinitfilterwebapp</artifactId>
     <name>AppEngine :: failinitfilterwebapp</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/failinitfilterwebapp/pom.xml
+++ b/runtime/failinitfilterwebapp/pom.xml
@@ -29,6 +29,7 @@
     <artifactId>failinitfilterwebapp</artifactId>
     <name>AppEngine :: failinitfilterwebapp</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A web application with a failing init filter.</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/failinitfilterwebapp/pom.xml
+++ b/runtime/failinitfilterwebapp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>runtime-parent</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>failinitfilterwebapp</artifactId>

--- a/runtime/failinitfilterwebappjakarta/pom.xml
+++ b/runtime/failinitfilterwebappjakarta/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>runtime-parent</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>failinitfilterwebappjakarta</artifactId>

--- a/runtime/failinitfilterwebappjakarta/pom.xml
+++ b/runtime/failinitfilterwebappjakarta/pom.xml
@@ -28,6 +28,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>failinitfilterwebappjakarta</artifactId>
     <name>AppEngine :: failinitfilterwebapp jakarta</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/failinitfilterwebappjakarta/pom.xml
+++ b/runtime/failinitfilterwebappjakarta/pom.xml
@@ -29,6 +29,7 @@
     <artifactId>failinitfilterwebappjakarta</artifactId>
     <name>AppEngine :: failinitfilterwebapp jakarta</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A web application with a failing init filter (Jakarta).</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/impl/pom.xml
+++ b/runtime/impl/pom.xml
@@ -28,6 +28,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-impl</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <dependencies>
         <dependency>

--- a/runtime/impl/pom.xml
+++ b/runtime/impl/pom.xml
@@ -29,6 +29,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-impl</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>App Engine runtime implementation.</description>
 
     <dependencies>
         <dependency>

--- a/runtime/impl/pom.xml
+++ b/runtime/impl/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>runtime-parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/runtime/lite/pom.xml
+++ b/runtime/lite/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>runtime-parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/runtime/local_jetty12/pom.xml
+++ b/runtime/local_jetty12/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime Jetty12</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>App Engine Local devappserver.</description>
   <properties>
     <maven.compiler.release>11</maven.compiler.release>

--- a/runtime/local_jetty12/pom.xml
+++ b/runtime/local_jetty12/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>runtime-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/runtime/local_jetty12_ee10/pom.xml
+++ b/runtime/local_jetty12_ee10/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>runtime-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/runtime/local_jetty12_ee10/pom.xml
+++ b/runtime/local_jetty12_ee10/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime Jetty12 EE10</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>App Engine Local devappserver.</description>
   <properties>
     <maven.compiler.release>11</maven.compiler.release>

--- a/runtime/local_jetty9/pom.xml
+++ b/runtime/local_jetty9/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-local-runtime Jetty9</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <description>App Engine Local devappserver.</description>
 
   <dependencies>

--- a/runtime/local_jetty9/pom.xml
+++ b/runtime/local_jetty9/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>runtime-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/runtime/main/pom.xml
+++ b/runtime/main/pom.xml
@@ -29,6 +29,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: runtime-main</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine runtime main.</description>
 
   <dependencies>
     <dependency>

--- a/runtime/main/pom.xml
+++ b/runtime/main/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>runtime-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/runtime/main/pom.xml
+++ b/runtime/main/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: runtime-main</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <dependencies>
     <dependency>

--- a/runtime/nogaeapiswebapp/pom.xml
+++ b/runtime/nogaeapiswebapp/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>runtime-parent</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>nogaeapiswebapp</artifactId>

--- a/runtime/nogaeapiswebapp/pom.xml
+++ b/runtime/nogaeapiswebapp/pom.xml
@@ -29,6 +29,7 @@
     <artifactId>nogaeapiswebapp</artifactId>
     <name>AppEngine :: nogaeapiswebapp</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A web application without App Engine APIs.</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/nogaeapiswebapp/pom.xml
+++ b/runtime/nogaeapiswebapp/pom.xml
@@ -28,6 +28,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>nogaeapiswebapp</artifactId>
     <name>AppEngine :: nogaeapiswebapp</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/nogaeapiswebappjakarta/pom.xml
+++ b/runtime/nogaeapiswebappjakarta/pom.xml
@@ -23,7 +23,7 @@
     <parent>
       <groupId>com.google.appengine</groupId>
       <artifactId>runtime-parent</artifactId>
-      <version>2.0.39-SNAPSHOT</version>
+      <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>nogaeapiswebappjakarta</artifactId>

--- a/runtime/nogaeapiswebappjakarta/pom.xml
+++ b/runtime/nogaeapiswebappjakarta/pom.xml
@@ -28,6 +28,7 @@
     <groupId>com.google.appengine.demos</groupId>
     <artifactId>nogaeapiswebappjakarta</artifactId>
     <name>AppEngine :: nogaeapiswebapp jakarta</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/nogaeapiswebappjakarta/pom.xml
+++ b/runtime/nogaeapiswebappjakarta/pom.xml
@@ -29,6 +29,7 @@
     <artifactId>nogaeapiswebappjakarta</artifactId>
     <name>AppEngine :: nogaeapiswebapp jakarta</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>A web application without App Engine APIs (Jakarta).</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -26,6 +26,7 @@
     <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <name>AppEngine :: runtime projects</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <packaging>pom</packaging>
 
   <modules>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <name>AppEngine :: runtime projects</name>
   <packaging>pom</packaging>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -27,6 +27,7 @@
   </parent>
   <name>AppEngine :: runtime projects</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Parent POM for App Engine runtime.</description>
   <packaging>pom</packaging>
 
   <modules>

--- a/runtime/runtime_impl_jetty12/pom.xml
+++ b/runtime/runtime_impl_jetty12/pom.xml
@@ -29,6 +29,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-impl Jetty12</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>App Engine runtime implementation for Jetty 12.</description>
 
     <dependencies>
         <dependency>

--- a/runtime/runtime_impl_jetty12/pom.xml
+++ b/runtime/runtime_impl_jetty12/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>runtime-parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/runtime/runtime_impl_jetty12/pom.xml
+++ b/runtime/runtime_impl_jetty12/pom.xml
@@ -28,6 +28,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-impl Jetty12</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <dependencies>
         <dependency>

--- a/runtime/runtime_impl_jetty9/pom.xml
+++ b/runtime/runtime_impl_jetty9/pom.xml
@@ -29,6 +29,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-impl Jetty9</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>App Engine runtime implementation for Jetty 9.</description>
 
     <dependencies>
         <dependency>

--- a/runtime/runtime_impl_jetty9/pom.xml
+++ b/runtime/runtime_impl_jetty9/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>runtime-parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/runtime/runtime_impl_jetty9/pom.xml
+++ b/runtime/runtime_impl_jetty9/pom.xml
@@ -28,6 +28,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-impl Jetty9</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <dependencies>
         <dependency>

--- a/runtime/test/pom.xml
+++ b/runtime/test/pom.xml
@@ -28,6 +28,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: runtime-test</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Tests for the App Engine runtime.</description>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/test/pom.xml
+++ b/runtime/test/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>runtime-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/runtime/test/pom.xml
+++ b/runtime/test/pom.xml
@@ -27,6 +27,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: runtime-test</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/test/src/test/java/com/google/apphosting/runtime/tests/GuestBookTest.java
+++ b/runtime/test/src/test/java/com/google/apphosting/runtime/tests/GuestBookTest.java
@@ -80,7 +80,7 @@ public final class GuestBookTest extends JavaRuntimeViaHttpBase {
                         ? ".cmd" // Windows OS
                         : ".sh"), // Linux OS.
                 "stage",
-                appRootTarget.getAbsolutePath() + "/target/" + appName + "-2.0.39-SNAPSHOT",
+                appRootTarget.getAbsolutePath() + "/target/" + appName + "-2.0.39-beta-SNAPSHOT",
                 appRootTarget.getAbsolutePath() + "/target/appengine-staging")
             .start();
     results = readOutput(process.getInputStream());

--- a/runtime/testapps/pom.xml
+++ b/runtime/testapps/pom.xml
@@ -28,6 +28,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: runtime-testapps</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>Test applications for the App Engine runtime.</description>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/testapps/pom.xml
+++ b/runtime/testapps/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>runtime-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/runtime/testapps/pom.xml
+++ b/runtime/testapps/pom.xml
@@ -27,6 +27,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: runtime-testapps</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>

--- a/runtime/util/pom.xml
+++ b/runtime/util/pom.xml
@@ -27,6 +27,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: runtime-util</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/runtime/util/pom.xml
+++ b/runtime/util/pom.xml
@@ -28,6 +28,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: runtime-util</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine runtime utilities.</description>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/runtime/util/pom.xml
+++ b/runtime/util/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>runtime-parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/runtime_shared/pom.xml
+++ b/runtime_shared/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/runtime_shared/pom.xml
+++ b/runtime_shared/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-shared</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>App Engine runtime shared components.</description>
 
     <dependencies>
         <dependency>

--- a/runtime_shared/pom.xml
+++ b/runtime_shared/pom.xml
@@ -27,6 +27,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-shared</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <dependencies>
         <dependency>

--- a/runtime_shared_jetty12/pom.xml
+++ b/runtime_shared_jetty12/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-shared Jetty12</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>App Engine runtime shared components for Jetty 12.</description>
 
   <dependencies>
         <dependency>

--- a/runtime_shared_jetty12/pom.xml
+++ b/runtime_shared_jetty12/pom.xml
@@ -27,6 +27,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-shared Jetty12</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <dependencies>
         <dependency>

--- a/runtime_shared_jetty12/pom.xml
+++ b/runtime_shared_jetty12/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/runtime_shared_jetty12/pom.xml
+++ b/runtime_shared_jetty12/pom.xml
@@ -160,6 +160,25 @@
                 </executions>
 
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <notimestamp>true</notimestamp>
+                    <show>public</show>
+                    <failOnWarnings>false</failOnWarnings>
+                    <doclint>none</doclint>
+                    <sourcepath>${project.basedir}/../runtime_shared</sourcepath>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/runtime_shared_jetty12_ee10/pom.xml
+++ b/runtime_shared_jetty12_ee10/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/runtime_shared_jetty12_ee10/pom.xml
+++ b/runtime_shared_jetty12_ee10/pom.xml
@@ -27,6 +27,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-shared Jetty12 EE10</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
   <dependencies>
         <dependency>

--- a/runtime_shared_jetty12_ee10/pom.xml
+++ b/runtime_shared_jetty12_ee10/pom.xml
@@ -153,6 +153,25 @@
                 </executions>
 
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <notimestamp>true</notimestamp>
+                    <show>public</show>
+                    <failOnWarnings>false</failOnWarnings>
+                    <doclint>none</doclint>
+                    <sourcepath>${project.basedir}/../runtime_shared</sourcepath>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/runtime_shared_jetty12_ee10/pom.xml
+++ b/runtime_shared_jetty12_ee10/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-shared Jetty12 EE10</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>App Engine runtime shared components for Jetty 12 and EE10.</description>
 
   <dependencies>
         <dependency>

--- a/runtime_shared_jetty9/pom.xml
+++ b/runtime_shared_jetty9/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/runtime_shared_jetty9/pom.xml
+++ b/runtime_shared_jetty9/pom.xml
@@ -27,6 +27,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-shared Jetty9</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
 
     <dependencies>
           <dependency>

--- a/runtime_shared_jetty9/pom.xml
+++ b/runtime_shared_jetty9/pom.xml
@@ -143,6 +143,25 @@
                 </executions>
 
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <notimestamp>true</notimestamp>
+                    <show>public</show>
+                    <failOnWarnings>false</failOnWarnings>
+                    <doclint>none</doclint>
+                    <sourcepath>${project.basedir}/../runtime_shared</sourcepath>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/runtime_shared_jetty9/pom.xml
+++ b/runtime_shared_jetty9/pom.xml
@@ -28,6 +28,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: runtime-shared Jetty9</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>App Engine runtime shared components for Jetty 9.</description>
 
     <dependencies>
           <dependency>

--- a/sdk_assembly/pom.xml
+++ b/sdk_assembly/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appengine-java-sdk</artifactId>

--- a/sdk_assembly/pom.xml
+++ b/sdk_assembly/pom.xml
@@ -25,6 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>appengine-java-sdk</artifactId>
     <name>AppEngine :: SDK Assembly</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
     <packaging>pom</packaging>
 
     <properties>

--- a/sessiondata/pom.xml
+++ b/sessiondata/pom.xml
@@ -29,6 +29,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: sessiondata</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine session data.</description>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/sessiondata/pom.xml
+++ b/sessiondata/pom.xml
@@ -23,7 +23,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
 
   <packaging>jar</packaging>

--- a/sessiondata/pom.xml
+++ b/sessiondata/pom.xml
@@ -28,6 +28,7 @@
 
   <packaging>jar</packaging>
   <name>AppEngine :: sessiondata</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>
   </properties>

--- a/shared_sdk/pom.xml
+++ b/shared_sdk/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/shared_sdk/pom.xml
+++ b/shared_sdk/pom.xml
@@ -26,6 +26,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
     <url>http://maven.apache.org</url>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>

--- a/shared_sdk/pom.xml
+++ b/shared_sdk/pom.xml
@@ -27,6 +27,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>Shared SDK.</description>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/shared_sdk/pom.xml
+++ b/shared_sdk/pom.xml
@@ -27,7 +27,6 @@
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
-    <url>http://maven.apache.org</url>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/shared_sdk_jetty12/pom.xml
+++ b/shared_sdk_jetty12/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/shared_sdk_jetty12/pom.xml
+++ b/shared_sdk_jetty12/pom.xml
@@ -27,7 +27,6 @@
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk Jetty12</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
-    <url>http://maven.apache.org</url>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/shared_sdk_jetty12/pom.xml
+++ b/shared_sdk_jetty12/pom.xml
@@ -27,6 +27,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk Jetty12</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>Shared SDK for Jetty 12.</description>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/shared_sdk_jetty12/pom.xml
+++ b/shared_sdk_jetty12/pom.xml
@@ -26,6 +26,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk Jetty12</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
     <url>http://maven.apache.org</url>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>

--- a/shared_sdk_jetty9/pom.xml
+++ b/shared_sdk_jetty9/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.google.appengine</groupId>
         <artifactId>parent</artifactId>
-        <version>2.0.39-SNAPSHOT</version>
+        <version>2.0.39-beta-SNAPSHOT</version>
     </parent>
 
     <packaging>jar</packaging>

--- a/shared_sdk_jetty9/pom.xml
+++ b/shared_sdk_jetty9/pom.xml
@@ -26,6 +26,7 @@
 
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk Jetty9</name>
+    <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
     <url>http://maven.apache.org</url>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>

--- a/shared_sdk_jetty9/pom.xml
+++ b/shared_sdk_jetty9/pom.xml
@@ -27,7 +27,6 @@
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk Jetty9</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
-    <url>http://maven.apache.org</url>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/shared_sdk_jetty9/pom.xml
+++ b/shared_sdk_jetty9/pom.xml
@@ -27,6 +27,7 @@
     <packaging>jar</packaging>
     <name>AppEngine :: shared-sdk Jetty9</name>
     <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+    <description>Shared SDK for Jetty 9.</description>
     <properties>
       <maven.deploy.skip>true</maven.deploy.skip>
     </properties>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -29,6 +29,7 @@
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-utils</name>
   <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
+  <description>App Engine utilities.</description>
   <dependencies>
     <dependency>
       <groupId>com.google.auto.service</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -28,6 +28,7 @@
   </properties>
   <packaging>jar</packaging>
   <name>AppEngine :: appengine-utils</name>
+  <url>https://github.com/GoogleCloudPlatform/appengine-java-standard/</url>
   <dependencies>
     <dependency>
       <groupId>com.google.auto.service</groupId>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>com.google.appengine</groupId>
     <artifactId>parent</artifactId>
-    <version>2.0.39-SNAPSHOT</version>
+    <version>2.0.39-beta-SNAPSHOT</version>
   </parent>
   <properties>
     <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
This PR is to review the `2.0.39-beta` version to get it for Beta release to Maven. This primarily is targeted at releasing the SMTP Mail changes to Beta customers

**Note:** This PR is not meant to be merged to `main` but only to be reviewed for correctness and released directly to maven from this branch. Hence only created a draft PR since it will never be ready to merge.

---

**Release Notes**

  This release introduces a major feature to the App Engine Mail API: the ability to send emails via an
  external SMTP service. This provides a more flexible and robust way to send emails from your App Engine
  application.

  Mail API: SMTP Support

  Key Features:

   * SMTP Mail Sending: Implemented the ability to send emails through a configured SMTP server. This
     functionality can be enabled by setting the USE_SMTP_MAIL_SERVICE environment variable.
   * Admin Email Support: AdminEmailMessage is now supported when using the SMTP transport. Recipients for
     admin emails are configured via the ADMIN_EMAIL_RECIPIENTS environment variable.
   * Error Handling & Resilience: Added specific error handling for common SMTP issues, such as authentication
     and connection errors, which are now surfaced as standard Mail API exceptions.
   * Comprehensive Tests: A full suite of unit tests has been added to ensure the reliability and correctness
     of the new SMTP sending functionality under various conditions.