### PR TITLE
deps: upgrade commons-lang3 to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -711,6 +711,11 @@
         <artifactId>google-cloud-logging</artifactId>
         <version>3.23.8</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>3.18.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
b/458152770

Before:
```
[INFO] --- dependency:3.9.0:tree (default-cli) @ appengine-java-sdk ---
[INFO] com.google.appengine:appengine-java-sdk:pom:3.0.3-SNAPSHOT
[INFO] \- com.google.appengine:jetty12-assembly:zip:3.0.3-SNAPSHOT:compile
[INFO]    \- org.eclipse.jetty:jetty-home:zip:9.4.58.v20250814:compile
[INFO]       \- org.eclipse.jetty:jetty-jaas:jar:9.4.58.v20250814:compile
[INFO]          \- org.apache.directory.api:api-ldap-model:jar:2.1.5:compile
[INFO]             \- org.apache.commons:commons-lang3:jar:3.13.0:compile
```

With this change:
```
[INFO] --- dependency:3.9.0:tree (default-cli) @ appengine-java-sdk ---
[INFO] com.google.appengine:appengine-java-sdk:pom:3.0.3-SNAPSHOT
[INFO] \- com.google.appengine:jetty12-assembly:zip:3.0.3-SNAPSHOT:compile
[INFO]    \- org.eclipse.jetty:jetty-home:zip:9.4.58.v20250814:compile
[INFO]       \- org.eclipse.jetty:jetty-jaas:jar:9.4.58.v20250814:compile
[INFO]          \- org.apache.directory.api:api-ldap-model:jar:2.1.5:compile
[INFO]             \- org.apache.commons:commons-lang3:jar:3.18.0:compile
```