### PR TITLE
Update image-server configuration environment variable names

### DIFF
--- a/api/src/main/java/com/google/appengine/api/images/GrpcImagesClient.java
+++ b/api/src/main/java/com/google/appengine/api/images/GrpcImagesClient.java
@@ -72,27 +72,40 @@ class GrpcImagesClient {
   }
 
   private String getTarget() {
-    String endpoint = environmentProvider.getenv("IMAGES_SERVICE_ENDPOINT");
+    String endpoint =
+        environmentProvider.getenv(ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV);
     if (isNullOrEmpty(endpoint)) {
-      throw new IllegalStateException("IMAGES_SERVICE_ENDPOINT environment variable not set.");
+      throw new IllegalStateException(
+          ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV + " environment variable not set.");
     }
     try {
       URI uri = new URI(endpoint);
       String host = uri.getHost();
       if (host == null) {
-        throw new IllegalStateException("Invalid URI in IMAGES_SERVICE_ENDPOINT: " + endpoint);
+        throw new IllegalStateException(
+            "Invalid URI in "
+                + ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV
+                + ": "
+                + endpoint);
       }
       return host + ":443";
     } catch (URISyntaxException e) {
-      throw new IllegalStateException("Invalid URI in IMAGES_SERVICE_ENDPOINT: " + endpoint, e);
+      throw new IllegalStateException(
+          "Invalid URI in "
+              + ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV
+              + ": "
+              + endpoint,
+          e);
     }
   }
 
   private static CallCredentials createOidcCredentials(
       EnvironmentProvider environmentProvider, GoogleCredentials googleCredentials) {
-    String endpoint = environmentProvider.getenv("IMAGES_SERVICE_ENDPOINT");
+    String endpoint =
+        environmentProvider.getenv(ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV);
     if (isNullOrEmpty(endpoint)) {
-      throw new IllegalStateException("IMAGES_SERVICE_ENDPOINT environment variable not set.");
+      throw new IllegalStateException(
+          ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV + " environment variable not set.");
     }
 
     if (!(googleCredentials instanceof IdTokenProvider idTokenProvider)) {

--- a/api/src/main/java/com/google/appengine/api/images/ImagesServiceFactoryImpl.java
+++ b/api/src/main/java/com/google/appengine/api/images/ImagesServiceFactoryImpl.java
@@ -33,7 +33,11 @@ import java.util.Collection;
 final class ImagesServiceFactoryImpl implements IImagesServiceFactory {
 
   @VisibleForTesting
-  static final String USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV = "USE_CUSTOM_IMAGES_GRPC_SERVICE";
+  static final String USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV =
+      "APPENGINE_USE_CUSTOM_IMAGES_GRPC_SERVICE";
+
+  @VisibleForTesting
+  static final String IMAGES_SERVICE_ENDPOINT_ENV = "APPENGINE_IMAGES_SERVICE_ENDPOINT";
 
   private EnvironmentProvider environmentProvider = new SystemEnvironmentProvider();
 

--- a/api/src/main/java/com/google/appengine/api/images/ImagesServiceImpl.java
+++ b/api/src/main/java/com/google/appengine/api/images/ImagesServiceImpl.java
@@ -164,7 +164,8 @@ final class ImagesServiceImpl implements ImagesService {
 
   @VisibleForTesting
   boolean useGrpc() {
-    String envVar = environmentProvider.getenv("USE_CUSTOM_IMAGES_GRPC_SERVICE");
+    String envVar =
+        environmentProvider.getenv(ImagesServiceFactoryImpl.USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV);
     return Boolean.parseBoolean(envVar);
   }
 

--- a/api/src/test/java/com/google/appengine/api/images/GrpcImagesClientTest.java
+++ b/api/src/test/java/com/google/appengine/api/images/GrpcImagesClientTest.java
@@ -37,7 +37,7 @@ public class GrpcImagesClientTest {
 
   @Test
   public void constructor_validEndpointAndCreds_success() {
-    when(mockEnvironmentProvider.getenv("IMAGES_SERVICE_ENDPOINT"))
+    when(mockEnvironmentProvider.getenv(ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV))
         .thenReturn("https://my-service.run.app");
 
     GrpcImagesClient client = new GrpcImagesClient(mockEnvironmentProvider, mockCallCredentials);
@@ -46,37 +46,47 @@ public class GrpcImagesClientTest {
 
   @Test
   public void constructor_endpointNotSet_throwsException() {
-    when(mockEnvironmentProvider.getenv("IMAGES_SERVICE_ENDPOINT")).thenReturn(null);
+    when(mockEnvironmentProvider.getenv(ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV))
+        .thenReturn(null);
     IllegalStateException e =
         assertThrows(
             IllegalStateException.class,
             () -> new GrpcImagesClient(mockEnvironmentProvider, mockCallCredentials));
-    assertThat(e).hasMessageThat().contains("IMAGES_SERVICE_ENDPOINT environment variable not set");
+    assertThat(e)
+        .hasMessageThat()
+        .contains(
+            ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV + " environment variable not set");
   }
 
   @Test
   public void constructor_invalidEndpoint_throwsException() {
-    when(mockEnvironmentProvider.getenv("IMAGES_SERVICE_ENDPOINT")).thenReturn("://my-service");
+    when(mockEnvironmentProvider.getenv(ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV))
+        .thenReturn("://my-service");
     IllegalStateException e =
         assertThrows(
             IllegalStateException.class,
             () -> new GrpcImagesClient(mockEnvironmentProvider, mockCallCredentials));
-    assertThat(e).hasMessageThat().contains("Invalid URI in IMAGES_SERVICE_ENDPOINT");
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Invalid URI in " + ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV);
   }
 
   @Test
   public void constructor_endpointMissingHost_throwsException() {
-    when(mockEnvironmentProvider.getenv("IMAGES_SERVICE_ENDPOINT")).thenReturn("https://");
+    when(mockEnvironmentProvider.getenv(ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV))
+        .thenReturn("https://");
     IllegalStateException e =
         assertThrows(
             IllegalStateException.class,
             () -> new GrpcImagesClient(mockEnvironmentProvider, mockCallCredentials));
-    assertThat(e).hasMessageThat().contains("Invalid URI in IMAGES_SERVICE_ENDPOINT");
+    assertThat(e)
+        .hasMessageThat()
+        .contains("Invalid URI in " + ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV);
   }
 
   @Test
   public void getBlockingStub_returnsStub() {
-    when(mockEnvironmentProvider.getenv("IMAGES_SERVICE_ENDPOINT"))
+    when(mockEnvironmentProvider.getenv(ImagesServiceFactoryImpl.IMAGES_SERVICE_ENDPOINT_ENV))
         .thenReturn("https://my-service.run.app");
     GrpcImagesClient client = new GrpcImagesClient(mockEnvironmentProvider, mockCallCredentials);
     assertThat(client.getBlockingStub()).isNotNull();

--- a/api/src/test/java/com/google/appengine/api/images/ImagesServiceFactoryImplTest.java
+++ b/api/src/test/java/com/google/appengine/api/images/ImagesServiceFactoryImplTest.java
@@ -41,7 +41,9 @@ public class ImagesServiceFactoryImplTest {
 
   @Test
   public void makeImageFromFilename_newBehavior_trueEnv_gsPrefix() {
-    when(mockEnvironmentProvider.getenv("USE_CUSTOM_IMAGES_GRPC_SERVICE")).thenReturn("true");
+    when(mockEnvironmentProvider.getenv(
+            ImagesServiceFactoryImpl.USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV))
+        .thenReturn("true");
     String filename = "/gs/bucket/object";
 
     // Should NOT call BlobstoreServiceFactory (which would fail in this env)
@@ -53,7 +55,9 @@ public class ImagesServiceFactoryImplTest {
 
   @Test
   public void makeImageFromFilename_newBehavior_trueEnv_noGsPrefix_throwsException() {
-    when(mockEnvironmentProvider.getenv("USE_CUSTOM_IMAGES_GRPC_SERVICE")).thenReturn("true");
+    when(mockEnvironmentProvider.getenv(
+            ImagesServiceFactoryImpl.USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV))
+        .thenReturn("true");
     String filename = "not/gs/path";
 
     IllegalArgumentException e =

--- a/api/src/test/java/com/google/appengine/api/images/ImagesServiceImplTest.java
+++ b/api/src/test/java/com/google/appengine/api/images/ImagesServiceImplTest.java
@@ -172,7 +172,9 @@ public class ImagesServiceImplTest {
         new ImagesServiceImpl(
             mockEnvironmentProvider, mockGrpcImagesClient, null, mockBlobstoreReference);
 
-    when(mockEnvironmentProvider.getenv("USE_CUSTOM_IMAGES_GRPC_SERVICE")).thenReturn("true");
+    when(mockEnvironmentProvider.getenv(
+            ImagesServiceFactoryImpl.USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV))
+        .thenReturn("true");
   }
 
   @Test
@@ -354,7 +356,8 @@ public class ImagesServiceImplTest {
 
   public void setUpGrpc(boolean useGrpc) throws Exception {
     ImagesServiceImpl.setStorageForTesting(mockStorage);
-    when(mockEnvironmentProvider.getenv("USE_CUSTOM_IMAGES_GRPC_SERVICE"))
+    when(mockEnvironmentProvider.getenv(
+            ImagesServiceFactoryImpl.USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV))
         .thenReturn(Boolean.toString(useGrpc));
 
     if (useGrpc) {
@@ -407,7 +410,9 @@ public class ImagesServiceImplTest {
 
   @Test
   public void useGrpc_envVarNotSet_returnsFalse() {
-    when(mockEnvironmentProvider.getenv("USE_CUSTOM_IMAGES_GRPC_SERVICE")).thenReturn(null);
+    when(mockEnvironmentProvider.getenv(
+            ImagesServiceFactoryImpl.USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV))
+        .thenReturn(null);
     imagesService =
         new ImagesServiceImpl(
             mockEnvironmentProvider, null, null, mockBlobstoreReference, null, mockBlobInfoFactory);
@@ -416,7 +421,9 @@ public class ImagesServiceImplTest {
 
   @Test
   public void useGrpc_envVarInvalid_returnsFalse() {
-    when(mockEnvironmentProvider.getenv("USE_CUSTOM_IMAGES_GRPC_SERVICE")).thenReturn("yes");
+    when(mockEnvironmentProvider.getenv(
+            ImagesServiceFactoryImpl.USE_CUSTOM_IMAGES_GRPC_SERVICE_ENV))
+        .thenReturn("yes");
     imagesService =
         new ImagesServiceImpl(
             mockEnvironmentProvider, null, null, mockBlobstoreReference, null, mockBlobInfoFactory);


### PR DESCRIPTION
Update image-server environment variable names to align with the standard naming conventions used across other bundled services.

Testing done:
```
appengine-java-standard $ ./mvnw test -pl api -T 32 

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  45.967 s (Wall Clock)
[INFO] Finished at: 2026-06-11T14:42:35Z
[INFO] ------------------------------------------------------------------------
```
