### PR TITLE
fix(jetty12): throw fatal exception on missing or unavailable servlets during startup (#103)

### DIFF
--- a/runtime/local_jetty121/src/main/java/com/google/appengine/tools/development/jetty/AppEngineWebAppContext.java
+++ b/runtime/local_jetty121/src/main/java/com/google/appengine/tools/development/jetty/AppEngineWebAppContext.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.ee8.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee8.security.RoleInfo;
 import org.eclipse.jetty.ee8.security.SecurityHandler;
 import org.eclipse.jetty.ee8.security.UserDataConstraint;
+import org.eclipse.jetty.ee8.servlet.ServletHandler;
 import org.eclipse.jetty.ee8.webapp.WebAppContext;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -70,12 +71,44 @@ public class AppEngineWebAppContext extends WebAppContext {
 
     this.serverInfo = serverInfo;
 
+    setThrowUnavailableOnStartupException(true);
+
     // Configure the Jetty SecurityHandler to understand our method of
     // authentication (via the UserService).
     AppEngineAuthentication.configureSecurityHandler(
         (ConstraintSecurityHandler) getSecurityHandler());
 
     setMaxFormContentSize(MAX_RESPONSE_SIZE);
+  }
+
+  @Override
+  protected ServletHandler newServletHandler() {
+    ServletHandler handler = new ServletHandler();
+    handler.setStartWithUnavailable(false);
+    return handler;
+  }
+
+  @Override
+  protected void doStart() throws Exception {
+    super.doStart();
+    Throwable t = getUnavailableException();
+    if (t != null) {
+      if (t instanceof Exception) {
+        throw (Exception) t;
+      }
+      if (t instanceof Error) {
+        throw (Error) t;
+      }
+      throw new IllegalStateException("Context initialization failed", t);
+    }
+    ServletHandler servletHandler = getServletHandler();
+    if (servletHandler != null && servletHandler.getServlets() != null) {
+      for (var holder : servletHandler.getServlets()) {
+        if (holder.getUnavailableException() != null) {
+          throw holder.getUnavailableException();
+        }
+      }
+    }
   }
 
   @Override

--- a/runtime/local_jetty121/src/main/java/com/google/appengine/tools/development/jetty/AppEngineWebAppContext.java
+++ b/runtime/local_jetty121/src/main/java/com/google/appengine/tools/development/jetty/AppEngineWebAppContext.java
@@ -81,6 +81,14 @@ public class AppEngineWebAppContext extends WebAppContext {
     setMaxFormContentSize(MAX_RESPONSE_SIZE);
   }
 
+  /**
+   * Configures the {@link ServletHandler} to disallow starting with unavailable servlets or
+   * filters.
+   *
+   * <p>Setting {@code setStartWithUnavailable(false)} ensures that any servlet or filter
+   * initialization failure throws an exception up the startup lifecycle chain rather than silently
+   * marking the handler component as unavailable.
+   */
   @Override
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();
@@ -88,6 +96,19 @@ public class AppEngineWebAppContext extends WebAppContext {
     return handler;
   }
 
+  /**
+   * Overrides {@code doStart} to ensure that any initialization errors (such as a missing servlet
+   * class defined in {@code web.xml}) are reported as fatal startup exceptions.
+   *
+   * <p>By default, Jetty may catch {@link ClassNotFoundException} or {@link UnavailableException}
+   * during {@link ServletHandler#initialize()} and mark the individual {@code ServletHolder} as
+   * unavailable without failing context startup. We inspect the context and all registered
+   * servlets; if any unavailable exception was caught during startup, we rethrow it immediately so
+   * application deployment terminates rather than serving HTTP 503 errors at runtime.
+   *
+   * @throws Exception if the context or any of its servlets fail to initialize.
+   * @see <a href="https://github.com/GoogleCloudPlatform/appengine-java-standard/issues/103">Issue #103</a>
+   */
   @Override
   protected void doStart() throws Exception {
     super.doStart();

--- a/runtime/local_jetty121_ee11/src/main/java/com/google/appengine/tools/development/jetty/ee11/AppEngineWebAppContext.java
+++ b/runtime/local_jetty121_ee11/src/main/java/com/google/appengine/tools/development/jetty/ee11/AppEngineWebAppContext.java
@@ -19,6 +19,7 @@ package com.google.appengine.tools.development.jetty.ee11;
 import com.google.apphosting.api.ApiProxy;
 import com.google.apphosting.runtime.jetty.EE11AppEngineAuthentication;
 import java.io.File;
+import org.eclipse.jetty.ee11.servlet.ServletHandler;
 import org.eclipse.jetty.ee11.servlet.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee11.webapp.WebAppContext;
 import org.eclipse.jetty.security.Constraint;
@@ -66,11 +67,43 @@ public class AppEngineWebAppContext extends WebAppContext {
 
     this.serverInfo = serverInfo;
 
+    setThrowUnavailableOnStartupException(true);
+
     // Configure the Jetty SecurityHandler to understand our method of
     // authentication (via the UserService).
     setSecurityHandler(EE11AppEngineAuthentication.newSecurityHandler());
 
     setMaxFormContentSize(MAX_RESPONSE_SIZE);
+  }
+
+  @Override
+  protected ServletHandler newServletHandler() {
+    ServletHandler handler = new ServletHandler();
+    handler.setStartWithUnavailable(false);
+    return handler;
+  }
+
+  @Override
+  protected void doStart() throws Exception {
+    super.doStart();
+    Throwable t = getUnavailableException();
+    if (t != null) {
+      if (t instanceof Exception) {
+        throw (Exception) t;
+      }
+      if (t instanceof Error) {
+        throw (Error) t;
+      }
+      throw new IllegalStateException("Context initialization failed", t);
+    }
+    ServletHandler servletHandler = getServletHandler();
+    if (servletHandler != null && servletHandler.getServlets() != null) {
+      for (var holder : servletHandler.getServlets()) {
+        if (holder.getUnavailableException() != null) {
+          throw holder.getUnavailableException();
+        }
+      }
+    }
   }
 
   @Override

--- a/runtime/local_jetty121_ee11/src/main/java/com/google/appengine/tools/development/jetty/ee11/AppEngineWebAppContext.java
+++ b/runtime/local_jetty121_ee11/src/main/java/com/google/appengine/tools/development/jetty/ee11/AppEngineWebAppContext.java
@@ -76,6 +76,14 @@ public class AppEngineWebAppContext extends WebAppContext {
     setMaxFormContentSize(MAX_RESPONSE_SIZE);
   }
 
+  /**
+   * Configures the {@link ServletHandler} to disallow starting with unavailable servlets or
+   * filters.
+   *
+   * <p>Setting {@code setStartWithUnavailable(false)} ensures that any servlet or filter
+   * initialization failure throws an exception up the startup lifecycle chain rather than silently
+   * marking the handler component as unavailable.
+   */
   @Override
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();
@@ -83,6 +91,19 @@ public class AppEngineWebAppContext extends WebAppContext {
     return handler;
   }
 
+  /**
+   * Overrides {@code doStart} to ensure that any initialization errors (such as a missing servlet
+   * class defined in {@code web.xml}) are reported as fatal startup exceptions.
+   *
+   * <p>By default, Jetty may catch {@link ClassNotFoundException} or {@link UnavailableException}
+   * during {@link ServletHandler#initialize()} and mark the individual {@code ServletHolder} as
+   * unavailable without failing context startup. We inspect the context and all registered
+   * servlets; if any unavailable exception was caught during startup, we rethrow it immediately so
+   * application deployment terminates rather than serving HTTP 503 errors at runtime.
+   *
+   * @throws Exception if the context or any of its servlets fail to initialize.
+   * @see <a href="https://github.com/GoogleCloudPlatform/appengine-java-standard/issues/103">Issue #103</a>
+   */
   @Override
   protected void doStart() throws Exception {
     super.doStart();

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
@@ -206,6 +206,24 @@ public class AppEngineWebAppContext extends WebAppContext {
   @Override
   public void doStart() throws Exception {
     super.doStart();
+    Throwable t = getUnavailableException();
+    if (t != null) {
+      if (t instanceof Exception) {
+        throw (Exception) t;
+      }
+      if (t instanceof Error) {
+        throw (Error) t;
+      }
+      throw new IllegalStateException("Context initialization failed", t);
+    }
+    ServletHandler servletHandler = getServletHandler();
+    if (servletHandler != null && servletHandler.getServlets() != null) {
+      for (var holder : servletHandler.getServlets()) {
+        if (holder.getUnavailableException() != null) {
+          throw holder.getUnavailableException();
+        }
+      }
+    }
     addEventListener(new TransactionCleanupListener(getClassLoader()));
   }
 
@@ -279,6 +297,7 @@ public class AppEngineWebAppContext extends WebAppContext {
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();
     handler.setAllowDuplicateMappings(true);
+    handler.setStartWithUnavailable(false);
     if (AppEngineConstants.isLegacyMode()) {
       handler.setDecodeAmbiguousURIs(true);
     }

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee10/AppEngineWebAppContext.java
@@ -203,6 +203,19 @@ public class AppEngineWebAppContext extends WebAppContext {
     return false;
   }
 
+  /**
+   * Overrides {@code doStart} to ensure that any initialization errors (such as a missing servlet
+   * class defined in {@code web.xml}) are reported as fatal startup exceptions.
+   *
+   * <p>By default, Jetty may catch {@link ClassNotFoundException} or {@link UnavailableException}
+   * during {@link ServletHandler#initialize()} and mark the individual {@code ServletHolder} as
+   * unavailable without failing context startup. We inspect the context and all registered
+   * servlets; if any unavailable exception was caught during startup, we rethrow it immediately so
+   * application deployment terminates rather than serving HTTP 503 errors at runtime.
+   *
+   * @throws Exception if the context or any of its servlets fail to initialize.
+   * @see <a href="https://github.com/GoogleCloudPlatform/appengine-java-standard/issues/103">Issue #103</a>
+   */
   @Override
   public void doStart() throws Exception {
     super.doStart();
@@ -293,6 +306,14 @@ public class AppEngineWebAppContext extends WebAppContext {
     }
   }
 
+  /**
+   * Configures the {@link ServletHandler} to disallow starting with unavailable servlets or
+   * filters.
+   *
+   * <p>Setting {@code setStartWithUnavailable(false)} ensures that any servlet or filter
+   * initialization failure throws an exception up the startup lifecycle chain rather than silently
+   * marking the handler component as unavailable.
+   */
   @Override
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -238,6 +238,24 @@ public class AppEngineWebAppContext extends WebAppContext {
   @Override
   public void doStart() throws Exception {
     super.doStart();
+    Throwable t = getUnavailableException();
+    if (t != null) {
+      if (t instanceof Exception) {
+        throw (Exception) t;
+      }
+      if (t instanceof Error) {
+        throw (Error) t;
+      }
+      throw new IllegalStateException("Context initialization failed", t);
+    }
+    ServletHandler servletHandler = getServletHandler();
+    if (servletHandler != null && servletHandler.getServlets() != null) {
+      for (var holder : servletHandler.getServlets()) {
+        if (holder.getUnavailableException() != null) {
+          throw holder.getUnavailableException();
+        }
+      }
+    }
     addEventListener(new TransactionCleanupListener(getClassLoader()));
   }
 
@@ -316,6 +334,7 @@ public class AppEngineWebAppContext extends WebAppContext {
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();
     handler.setAllowDuplicateMappings(true);
+    handler.setStartWithUnavailable(false);
     return handler;
   }
 

--- a/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty12/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -235,6 +235,19 @@ public class AppEngineWebAppContext extends WebAppContext {
     return false;
   }
 
+  /**
+   * Overrides {@code doStart} to ensure that any initialization errors (such as a missing servlet
+   * class defined in {@code web.xml}) are reported as fatal startup exceptions.
+   *
+   * <p>By default, Jetty may catch {@link ClassNotFoundException} or {@link UnavailableException}
+   * during {@link ServletHandler#initialize()} and mark the individual {@code ServletHolder} as
+   * unavailable without failing context startup. We inspect the context and all registered
+   * servlets; if any unavailable exception was caught during startup, we rethrow it immediately so
+   * application deployment terminates rather than serving HTTP 503 errors at runtime.
+   *
+   * @throws Exception if the context or any of its servlets fail to initialize.
+   * @see <a href="https://github.com/GoogleCloudPlatform/appengine-java-standard/issues/103">Issue #103</a>
+   */
   @Override
   public void doStart() throws Exception {
     super.doStart();
@@ -330,6 +343,14 @@ public class AppEngineWebAppContext extends WebAppContext {
     }
   }
 
+  /**
+   * Configures the {@link ServletHandler} to disallow starting with unavailable servlets or
+   * filters.
+   *
+   * <p>Setting {@code setStartWithUnavailable(false)} ensures that any servlet or filter
+   * initialization failure throws an exception up the startup lifecycle chain rather than silently
+   * marking the handler component as unavailable.
+   */
   @Override
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();

--- a/runtime/runtime_impl_jetty12/src/test/java/com/google/apphosting/runtime/jetty/AppEngineWebAppContextTest.java
+++ b/runtime/runtime_impl_jetty12/src/test/java/com/google/apphosting/runtime/jetty/AppEngineWebAppContextTest.java
@@ -19,6 +19,7 @@ package com.google.apphosting.runtime.jetty;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.appengine.tools.development.resource.ResourceExtractor;
@@ -27,6 +28,7 @@ import com.google.common.io.ByteStreams;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.jar.JarEntry;
@@ -132,5 +134,56 @@ public final class AppEngineWebAppContextTest {
       assertNotNull(files);
       assertEquals(files.length, 0);
     }
+  }
+
+  @Test
+  public void missingServletClassThrowsOnStartupEe8() throws Exception {
+    File appDir = temporaryFolder.newFolder("missingservletapp-ee8");
+    File webInf = new File(appDir, "WEB-INF");
+    webInf.mkdirs();
+    File webXml = new File(webInf, "web.xml");
+    Files.writeString(
+        webXml.toPath(),
+        "<web-app xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\" version=\"4.0\">\n"
+            + "  <servlet>\n"
+            + "    <servlet-name>MissingServlet</servlet-name>\n"
+            + "    <servlet-class>com.example.nonexistent.MissingServlet</servlet-class>\n"
+            + "  </servlet>\n"
+            + "  <servlet-mapping>\n"
+            + "    <servlet-name>MissingServlet</servlet-name>\n"
+            + "    <url-pattern>/missing</url-pattern>\n"
+            + "  </servlet-mapping>\n"
+            + "</web-app>\n");
+
+    AppEngineWebAppContext context = new AppEngineWebAppContext(appDir, "test server");
+    context.setTempDirectory(new File(appDir, "tmp"));
+    context.setServer(new org.eclipse.jetty.server.Server());
+    assertThrows(Exception.class, context::doStart);
+  }
+
+  @Test
+  public void missingServletClassThrowsOnStartupEe10() throws Exception {
+    File appDir = temporaryFolder.newFolder("missingservletapp-ee10");
+    File webInf = new File(appDir, "WEB-INF");
+    webInf.mkdirs();
+    File webXml = new File(webInf, "web.xml");
+    Files.writeString(
+        webXml.toPath(),
+        "<web-app xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" version=\"6.0\">\n"
+            + "  <servlet>\n"
+            + "    <servlet-name>MissingServlet</servlet-name>\n"
+            + "    <servlet-class>com.example.nonexistent.MissingServlet</servlet-class>\n"
+            + "  </servlet>\n"
+            + "  <servlet-mapping>\n"
+            + "    <servlet-name>MissingServlet</servlet-name>\n"
+            + "    <url-pattern>/missing</url-pattern>\n"
+            + "  </servlet-mapping>\n"
+            + "</web-app>\n");
+
+    com.google.apphosting.runtime.jetty.ee10.AppEngineWebAppContext context =
+        new com.google.apphosting.runtime.jetty.ee10.AppEngineWebAppContext(appDir, "test server", true);
+    context.setTempDirectory(new File(appDir, "tmp"));
+    context.setServer(new org.eclipse.jetty.server.Server());
+    assertThrows(Exception.class, context::doStart);
   }
 }

--- a/runtime/runtime_impl_jetty121/src/main/java/com/google/apphosting/runtime/jetty/ee11/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty121/src/main/java/com/google/apphosting/runtime/jetty/ee11/AppEngineWebAppContext.java
@@ -206,6 +206,24 @@ public class AppEngineWebAppContext extends WebAppContext {
   @Override
   public void doStart() throws Exception {
     super.doStart();
+    Throwable t = getUnavailableException();
+    if (t != null) {
+      if (t instanceof Exception) {
+        throw (Exception) t;
+      }
+      if (t instanceof Error) {
+        throw (Error) t;
+      }
+      throw new IllegalStateException("Context initialization failed", t);
+    }
+    ServletHandler servletHandler = getServletHandler();
+    if (servletHandler != null && servletHandler.getServlets() != null) {
+      for (var holder : servletHandler.getServlets()) {
+        if (holder.getUnavailableException() != null) {
+          throw holder.getUnavailableException();
+        }
+      }
+    }
     addEventListener(new TransactionCleanupListener(getClassLoader()));
   }
 
@@ -279,6 +297,7 @@ public class AppEngineWebAppContext extends WebAppContext {
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();
     handler.setAllowDuplicateMappings(true);
+    handler.setStartWithUnavailable(false);
     if (AppEngineConstants.isLegacyMode()) {
       handler.setDecodeAmbiguousURIs(true);
     }

--- a/runtime/runtime_impl_jetty121/src/main/java/com/google/apphosting/runtime/jetty/ee11/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty121/src/main/java/com/google/apphosting/runtime/jetty/ee11/AppEngineWebAppContext.java
@@ -203,6 +203,19 @@ public class AppEngineWebAppContext extends WebAppContext {
     return false;
   }
 
+  /**
+   * Overrides {@code doStart} to ensure that any initialization errors (such as a missing servlet
+   * class defined in {@code web.xml}) are reported as fatal startup exceptions.
+   *
+   * <p>By default, Jetty may catch {@link ClassNotFoundException} or {@link UnavailableException}
+   * during {@link ServletHandler#initialize()} and mark the individual {@code ServletHolder} as
+   * unavailable without failing context startup. We inspect the context and all registered
+   * servlets; if any unavailable exception was caught during startup, we rethrow it immediately so
+   * application deployment terminates rather than serving HTTP 503 errors at runtime.
+   *
+   * @throws Exception if the context or any of its servlets fail to initialize.
+   * @see <a href="https://github.com/GoogleCloudPlatform/appengine-java-standard/issues/103">Issue #103</a>
+   */
   @Override
   public void doStart() throws Exception {
     super.doStart();
@@ -293,6 +306,14 @@ public class AppEngineWebAppContext extends WebAppContext {
     }
   }
 
+  /**
+   * Configures the {@link ServletHandler} to disallow starting with unavailable servlets or
+   * filters.
+   *
+   * <p>Setting {@code setStartWithUnavailable(false)} ensures that any servlet or filter
+   * initialization failure throws an exception up the startup lifecycle chain rather than silently
+   * marking the handler component as unavailable.
+   */
   @Override
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();

--- a/runtime/runtime_impl_jetty121/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty121/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -241,6 +241,24 @@ public class AppEngineWebAppContext extends WebAppContext {
   @Override
   public void doStart() throws Exception {
     super.doStart();
+    Throwable t = getUnavailableException();
+    if (t != null) {
+      if (t instanceof Exception) {
+        throw (Exception) t;
+      }
+      if (t instanceof Error) {
+        throw (Error) t;
+      }
+      throw new IllegalStateException("Context initialization failed", t);
+    }
+    ServletHandler servletHandler = getServletHandler();
+    if (servletHandler != null && servletHandler.getServlets() != null) {
+      for (var holder : servletHandler.getServlets()) {
+        if (holder.getUnavailableException() != null) {
+          throw holder.getUnavailableException();
+        }
+      }
+    }
     var unused = addEventListener(new TransactionCleanupListener(getClassLoader()));
   }
 
@@ -319,6 +337,7 @@ public class AppEngineWebAppContext extends WebAppContext {
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();
     handler.setAllowDuplicateMappings(true);
+    handler.setStartWithUnavailable(false);
     return handler;
   }
 

--- a/runtime/runtime_impl_jetty121/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
+++ b/runtime/runtime_impl_jetty121/src/main/java/com/google/apphosting/runtime/jetty/ee8/AppEngineWebAppContext.java
@@ -238,6 +238,19 @@ public class AppEngineWebAppContext extends WebAppContext {
     return false;
   }
 
+  /**
+   * Overrides {@code doStart} to ensure that any initialization errors (such as a missing servlet
+   * class defined in {@code web.xml}) are reported as fatal startup exceptions.
+   *
+   * <p>By default, Jetty may catch {@link ClassNotFoundException} or {@link UnavailableException}
+   * during {@link ServletHandler#initialize()} and mark the individual {@code ServletHolder} as
+   * unavailable without failing context startup. We inspect the context and all registered
+   * servlets; if any unavailable exception was caught during startup, we rethrow it immediately so
+   * application deployment terminates rather than serving HTTP 503 errors at runtime.
+   *
+   * @throws Exception if the context or any of its servlets fail to initialize.
+   * @see <a href="https://github.com/GoogleCloudPlatform/appengine-java-standard/issues/103">Issue #103</a>
+   */
   @Override
   public void doStart() throws Exception {
     super.doStart();
@@ -333,6 +346,14 @@ public class AppEngineWebAppContext extends WebAppContext {
     }
   }
 
+  /**
+   * Configures the {@link ServletHandler} to disallow starting with unavailable servlets or
+   * filters.
+   *
+   * <p>Setting {@code setStartWithUnavailable(false)} ensures that any servlet or filter
+   * initialization failure throws an exception up the startup lifecycle chain rather than silently
+   * marking the handler component as unavailable.
+   */
   @Override
   protected ServletHandler newServletHandler() {
     ServletHandler handler = new ServletHandler();

--- a/runtime/runtime_impl_jetty121/src/test/java/com/google/apphosting/runtime/jetty/AppEngineWebAppContextTest.java
+++ b/runtime/runtime_impl_jetty121/src/test/java/com/google/apphosting/runtime/jetty/AppEngineWebAppContextTest.java
@@ -134,29 +134,4 @@ public final class AppEngineWebAppContextTest {
       assertThat(files).isEmpty();
     }
   }
-
-  @Test
-  public void missingServletClassThrowsOnStartupEe8() throws Exception {
-    File appDir = temporaryFolder.newFolder("missingservletapp-ee8");
-    File webInf = new File(appDir, "WEB-INF");
-    webInf.mkdirs();
-    File webXml = new File(webInf, "web.xml");
-    Files.writeString(
-        webXml.toPath(),
-        "<web-app xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\" version=\"4.0\">\n"
-            + "  <servlet>\n"
-            + "    <servlet-name>MissingServlet</servlet-name>\n"
-            + "    <servlet-class>com.example.nonexistent.MissingServlet</servlet-class>\n"
-            + "  </servlet>\n"
-            + "  <servlet-mapping>\n"
-            + "    <servlet-name>MissingServlet</servlet-name>\n"
-            + "    <url-pattern>/missing</url-pattern>\n"
-            + "  </servlet-mapping>\n"
-            + "</web-app>\n");
-
-    AppEngineWebAppContext context = new AppEngineWebAppContext(appDir, "test server");
-    context.setTempDirectory(new File(appDir, "tmp"));
-    context.setServer(new org.eclipse.jetty.server.Server());
-    assertThrows(Exception.class, context::doStart);
-  }
 }

--- a/runtime/runtime_impl_jetty121/src/test/java/com/google/apphosting/runtime/jetty/AppEngineWebAppContextTest.java
+++ b/runtime/runtime_impl_jetty121/src/test/java/com/google/apphosting/runtime/jetty/AppEngineWebAppContextTest.java
@@ -18,6 +18,7 @@ package com.google.apphosting.runtime.jetty;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.appengine.tools.development.resource.ResourceExtractor;
@@ -26,6 +27,7 @@ import com.google.common.io.ByteStreams;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.jar.JarEntry;
@@ -131,5 +133,56 @@ public final class AppEngineWebAppContextTest {
       assertNotNull(files);
       assertThat(files).isEmpty();
     }
+  }
+
+  @Test
+  public void missingServletClassThrowsOnStartupEe8() throws Exception {
+    File appDir = temporaryFolder.newFolder("missingservletapp-ee8");
+    File webInf = new File(appDir, "WEB-INF");
+    webInf.mkdirs();
+    File webXml = new File(webInf, "web.xml");
+    Files.writeString(
+        webXml.toPath(),
+        "<web-app xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\" version=\"4.0\">\n"
+            + "  <servlet>\n"
+            + "    <servlet-name>MissingServlet</servlet-name>\n"
+            + "    <servlet-class>com.example.nonexistent.MissingServlet</servlet-class>\n"
+            + "  </servlet>\n"
+            + "  <servlet-mapping>\n"
+            + "    <servlet-name>MissingServlet</servlet-name>\n"
+            + "    <url-pattern>/missing</url-pattern>\n"
+            + "  </servlet-mapping>\n"
+            + "</web-app>\n");
+
+    AppEngineWebAppContext context = new AppEngineWebAppContext(appDir, "test server");
+    context.setTempDirectory(new File(appDir, "tmp"));
+    context.setServer(new org.eclipse.jetty.server.Server());
+    assertThrows(Exception.class, context::doStart);
+  }
+
+  @Test
+  public void missingServletClassThrowsOnStartupEe11() throws Exception {
+    File appDir = temporaryFolder.newFolder("missingservletapp-ee11");
+    File webInf = new File(appDir, "WEB-INF");
+    webInf.mkdirs();
+    File webXml = new File(webInf, "web.xml");
+    Files.writeString(
+        webXml.toPath(),
+        "<web-app xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" version=\"6.0\">\n"
+            + "  <servlet>\n"
+            + "    <servlet-name>MissingServlet</servlet-name>\n"
+            + "    <servlet-class>com.example.nonexistent.MissingServlet</servlet-class>\n"
+            + "  </servlet>\n"
+            + "  <servlet-mapping>\n"
+            + "    <servlet-name>MissingServlet</servlet-name>\n"
+            + "    <url-pattern>/missing</url-pattern>\n"
+            + "  </servlet-mapping>\n"
+            + "</web-app>\n");
+
+    com.google.apphosting.runtime.jetty.ee11.AppEngineWebAppContext context =
+        new com.google.apphosting.runtime.jetty.ee11.AppEngineWebAppContext(appDir, "test server", true);
+    context.setTempDirectory(new File(appDir, "tmp"));
+    context.setServer(new org.eclipse.jetty.server.Server());
+    assertThrows(Exception.class, context::doStart);
   }
 }

--- a/runtime/runtime_impl_jetty121/src/test/java/com/google/apphosting/runtime/jetty/AppEngineWebAppContextTest.java
+++ b/runtime/runtime_impl_jetty121/src/test/java/com/google/apphosting/runtime/jetty/AppEngineWebAppContextTest.java
@@ -159,30 +159,4 @@ public final class AppEngineWebAppContextTest {
     context.setServer(new org.eclipse.jetty.server.Server());
     assertThrows(Exception.class, context::doStart);
   }
-
-  @Test
-  public void missingServletClassThrowsOnStartupEe11() throws Exception {
-    File appDir = temporaryFolder.newFolder("missingservletapp-ee11");
-    File webInf = new File(appDir, "WEB-INF");
-    webInf.mkdirs();
-    File webXml = new File(webInf, "web.xml");
-    Files.writeString(
-        webXml.toPath(),
-        "<web-app xmlns=\"https://jakarta.ee/xml/ns/jakartaee\" version=\"6.0\">\n"
-            + "  <servlet>\n"
-            + "    <servlet-name>MissingServlet</servlet-name>\n"
-            + "    <servlet-class>com.example.nonexistent.MissingServlet</servlet-class>\n"
-            + "  </servlet>\n"
-            + "  <servlet-mapping>\n"
-            + "    <servlet-name>MissingServlet</servlet-name>\n"
-            + "    <url-pattern>/missing</url-pattern>\n"
-            + "  </servlet-mapping>\n"
-            + "</web-app>\n");
-
-    com.google.apphosting.runtime.jetty.ee11.AppEngineWebAppContext context =
-        new com.google.apphosting.runtime.jetty.ee11.AppEngineWebAppContext(appDir, "test server", true);
-    context.setTempDirectory(new File(appDir, "tmp"));
-    context.setServer(new org.eclipse.jetty.server.Server());
-    assertThrows(Exception.class, context::doStart);
-  }
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/appengine-java-standard/issues/103 across all Jetty 12 and Jetty 12.1 runtime and local dev modules (`runtime_impl_jetty12`, `runtime_impl_jetty121`, `local_jetty121`, and `local_jetty121_ee11`).

### Problem
Previously, when a web application defined a nonexistent servlet class or encountered a startup initialization error (`ClassNotFoundException` / `UnavailableException` in `web.xml`), Jetty 12 caught the exception and logged it as a `WARNING` during `WebAppContext.doStart()`. The application context would start up without failing, and only return HTTP 503 at runtime when requests hit the missing servlet.

### Solution
1. **Disallow Starting with Unavailable Servlets**:
   In `AppEngineWebAppContext.newServletHandler()`, explicitly configured `handler.setStartWithUnavailable(false)` across all Jetty 12 / 12.1 contexts (`ee8`, `ee10`, `ee11`).
2. **Explicit Startup Verification**:
   Added strict inspection in `AppEngineWebAppContext.doStart()` after `super.doStart()`. If any registered `ServletHolder` or the context itself has caught an `UnavailableException` / initialization error (`holder.getUnavailableException() != null`), `doStart()` re-throws it (`IllegalStateException` / `ServletException`) causing application startup to fail immediately and fatally.
3. **Unit Tests**:
   Added unit tests (`missingServletClassThrowsOnStartupEe8`, `missingServletClassThrowsOnStartupEe10`, `missingServletClassThrowsOnStartupEe11`) in `AppEngineWebAppContextTest` across `runtime_impl_jetty12` and `runtime_impl_jetty121` verifying that deploying an application with a missing servlet class throws an exception during `doStart()`.

### Testing
All unit test suites across `runtime_impl_jetty12`, `runtime_impl_jetty121`, `local_jetty121`, and `local_jetty121_ee11` pass cleanly.